### PR TITLE
Adding owner to config keys and analytics

### DIFF
--- a/app/src/androidTest/java/com/jraska/github/client/FirebaseEventConverterTest.kt
+++ b/app/src/androidTest/java/com/jraska/github/client/FirebaseEventConverterTest.kt
@@ -7,15 +7,16 @@ import org.junit.Test
 class FirebaseEventConverterTest {
   @Test
   fun convertsProperly() {
-    val event = AnalyticsEvent.builder("whatever")
-      .addProperty("boolean", true)
-      .addProperty("int", 8)
-      .addProperty("double", 3.4)
-      .addProperty("string", "Hello")
-      .addProperty("long", 123L)
-      .build()
+    val event = AnalyticsEvent.builder(
+      AnalyticsEvent.Key("whatever", Owner.CORE_TEAM))
+        .addProperty("boolean", true)
+        .addProperty("int", 8)
+        .addProperty("double", 3.4)
+        .addProperty("string", "Hello")
+        .addProperty("long", 123L)
+        .build()
 
-    val firebaseBundle = FirebaseEventConverter.firebaseBundle(event.properties)!!
+      val firebaseBundle = FirebaseEventConverter . firebaseBundle (event.properties)!!
 
     assertThat(firebaseBundle.getInt("boolean")).isEqualTo(1)
     assertThat(firebaseBundle.getDouble("double")).isEqualTo(3.4)

--- a/app/src/main/java/com/jraska/github/client/FirebaseConfigProxy.kt
+++ b/app/src/main/java/com/jraska/github/client/FirebaseConfigProxy.kt
@@ -12,16 +12,16 @@ internal class FirebaseConfigProxy(private val config: FirebaseRemoteConfig) : C
       Date(config.info.fetchTimeMillis))
   }
 
-  override fun getBoolean(key: String): Boolean {
-    return config.getBoolean(key)
+  override fun getBoolean(key: Config.Key): Boolean {
+    return config.getBoolean(key.name)
   }
 
-  override fun getLong(key: String): Long {
-    return config.getLong(key)
+  override fun getLong(key: Config.Key): Long {
+    return config.getLong(key.name)
   }
 
-  override fun getString(key: String): String {
-    return config.getString(key)
+  override fun getString(key: Config.Key): String {
+    return config.getString(key.name)
   }
 
   override fun triggerRefresh() {

--- a/app/src/main/java/com/jraska/github/client/FirebaseModule.kt
+++ b/app/src/main/java/com/jraska/github/client/FirebaseModule.kt
@@ -13,13 +13,15 @@ import timber.log.Timber
 import javax.inject.Singleton
 
 @Module
-class FirebaseModule {
+object FirebaseModule {
+
+  val ANALYTICS_DISABLED_KEY = Config.Key("analytics_disabled", Owner.CORE_TEAM)
 
   @Provides
   @Singleton internal fun firebaseAnalytics(config: Config): FirebaseEventAnalytics {
     val firebaseAnalytics = FirebaseAnalytics.getInstance(FirebaseApp.getInstance().applicationContext)
 
-    if (config.getBoolean("analytics_disabled")) {
+    if (config.getBoolean(ANALYTICS_DISABLED_KEY)) {
       firebaseAnalytics.setAnalyticsCollectionEnabled(false)
       Timber.d("Analytics disabled")
     } else {

--- a/core-android/src/main/java/com/jraska/github/client/core/android/CoreAndroidModule.kt
+++ b/core-android/src/main/java/com/jraska/github/client/core/android/CoreAndroidModule.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.jraska.github.client.DeepLinkLauncher
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import com.jraska.github.client.core.android.logging.SetupLogging
@@ -94,7 +95,7 @@ object CoreAndroidModule {
   fun reportAppCreateEvent(eventAnalytics: EventAnalytics): OnAppCreate {
     return object : OnAppCreate {
       override fun onCreate(app: Application) {
-        val createEvent = AnalyticsEvent.create("app_create")
+        val createEvent = AnalyticsEvent.create(AnalyticsEvent.Key("app_create", Owner.CORE_TEAM))
         eventAnalytics.report(createEvent)
       }
     }

--- a/core-android/src/main/java/com/jraska/github/client/core/android/UriHandlerViewModel.kt
+++ b/core-android/src/main/java/com/jraska/github/client/core/android/UriHandlerViewModel.kt
@@ -2,6 +2,7 @@ package com.jraska.github.client.core.android
 
 import androidx.lifecycle.ViewModel
 import com.jraska.github.client.DeepLinkHandler
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import com.jraska.github.client.analytics.toAnalyticsString
@@ -16,10 +17,14 @@ class UriHandlerViewModel @Inject constructor(
   fun handleDeepLink(deepLink: HttpUrl) {
     val success = deepLinkHandler.handleDeepLink(deepLink)
 
-    val event = AnalyticsEvent.builder("deep_link_received")
+    val event = AnalyticsEvent.builder(ANALYTICS_DEEP_LINK_KEY)
       .addProperty("deep_link", deepLink.toAnalyticsString())
       .addProperty("success", success.toBoolean())
       .build()
     eventAnalytics.report(event)
+  }
+
+  companion object {
+    val ANALYTICS_DEEP_LINK_KEY = AnalyticsEvent.Key("deep_link_received", Owner.CORE_TEAM)
   }
 }

--- a/core-testing/src/main/java/com/jraska/github/client/FakeConfig.kt
+++ b/core-testing/src/main/java/com/jraska/github/client/FakeConfig.kt
@@ -6,16 +6,16 @@ class FakeConfig private constructor(private val values: MutableMap<String, Any>
     // do nothing
   }
 
-  override fun getBoolean(key: String): Boolean {
-    return (values[key] ?: false) as Boolean
+  override fun getBoolean(key: Config.Key): Boolean {
+    return (values[key.name] ?: false) as Boolean
   }
 
-  override fun getString(key: String): String {
-    return (values[key] ?: "") as String
+  override fun getString(key: Config.Key): String {
+    return (values[key.name] ?: "") as String
   }
 
-  override fun getLong(key: String): Long {
-    return (values[key] ?: 0L) as Long
+  override fun getLong(key: Config.Key): Long {
+    return (values[key.name] ?: 0L) as Long
   }
 
   fun set(key: String, value: Any): RevertSet {

--- a/core/src/main/java/com/jraska/github/client/Config.kt
+++ b/core/src/main/java/com/jraska/github/client/Config.kt
@@ -3,9 +3,11 @@ package com.jraska.github.client
 interface Config {
   fun triggerRefresh()
 
-  fun getBoolean(key: String): Boolean
+  fun getBoolean(key: Key): Boolean
 
-  fun getLong(key: String): Long
+  fun getLong(key: Key): Long
 
-  fun getString(key: String): String
+  fun getString(key: Key): String
+
+  class Key(val name: String, val owner: Owner)
 }

--- a/core/src/main/java/com/jraska/github/client/Owner.kt
+++ b/core/src/main/java/com/jraska/github/client/Owner.kt
@@ -1,0 +1,20 @@
+package com.jraska.github.client
+
+/**
+ * This enum is a demonstration how to scale maintenance of keys like analytics and remote configuration over the long term.
+ *
+ * - All keys, which are interacting with external system have to have an owner.
+ * - The reason for that is the input for these is dynamic, by time it is not clear if they are still used or consumed and tracing them is difficult.
+ *
+ * - Each type of a resource coming from outside has also a stale state after some time of inactivity during keys audit.
+ * - In case of some key being stale - it can be deleted together with related code.
+ * - At the moment some key has an Owner#Unknown - it becomes stale.
+ *
+ * @see AnalyticsEvent.Key
+ * @see Config.Key for remote configuration
+ */
+enum class Owner {
+  CORE_TEAM,
+  USERS_TEAM,
+  UNKNOWN // Stale! Can be deleted at any moment during resource key audit.
+}

--- a/core/src/main/java/com/jraska/github/client/analytics/AnalyticsEvent.kt
+++ b/core/src/main/java/com/jraska/github/client/analytics/AnalyticsEvent.kt
@@ -1,13 +1,18 @@
 package com.jraska.github.client.analytics
 
+import com.jraska.github.client.Owner
 import java.util.Collections
 
 class AnalyticsEvent private constructor(
-  val name: String,
+  val key: Key,
   val properties: Map<String, Any>
 ) {
 
-  class Builder internal constructor(private val name: String) {
+  val name get() = key.name
+
+  class Key(val name: String, val owner: Owner)
+
+  class Builder internal constructor(private val key: Key) {
     private val properties = HashMap<String, Any>()
 
     private fun addAny(name: String, value: Any): Builder {
@@ -36,17 +41,17 @@ class AnalyticsEvent private constructor(
     }
 
     fun build(): AnalyticsEvent {
-      return AnalyticsEvent(name, Collections.unmodifiableMap(properties))
+      return AnalyticsEvent(key, Collections.unmodifiableMap(properties))
     }
   }
 
   companion object {
-    fun create(name: String): AnalyticsEvent {
-      return AnalyticsEvent(name, emptyMap())
+    fun create(key: Key): AnalyticsEvent {
+      return AnalyticsEvent(key, emptyMap())
     }
 
-    fun builder(name: String): Builder {
-      return Builder(name)
+    fun builder(key: Key): Builder {
+      return Builder(key)
     }
   }
 }

--- a/feature/about/src/main/java/com/jraska/github/client/about/AboutViewModel.kt
+++ b/feature/about/src/main/java/com/jraska/github/client/about/AboutViewModel.kt
@@ -1,6 +1,7 @@
 package com.jraska.github.client.about
 
 import androidx.lifecycle.ViewModel
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import com.jraska.github.client.analytics.toAnalyticsString
@@ -37,7 +38,7 @@ internal class AboutViewModel @Inject constructor(
 
   private fun openUrl(urlText: String) {
     val url = urlText.toHttpUrl()
-    val event = AnalyticsEvent.builder("about_clicked")
+    val event = AnalyticsEvent.builder(ANALYTICS_ABOUT_CLICKED)
       .addProperty("url", url.toAnalyticsString())
       .addProperty("user_id", identityProvider.session().userId.toString())
       .build()
@@ -45,5 +46,9 @@ internal class AboutViewModel @Inject constructor(
     analytics.report(event)
 
     navigator.launchOnWeb(url)
+  }
+
+  companion object {
+    val ANALYTICS_ABOUT_CLICKED = AnalyticsEvent.Key("about_clicked", Owner.USERS_TEAM)
   }
 }

--- a/feature/push/src/main/java/com/jraska/github/client/push/ConfigAsPropertyCommand.kt
+++ b/feature/push/src/main/java/com/jraska/github/client/push/ConfigAsPropertyCommand.kt
@@ -1,6 +1,7 @@
 package com.jraska.github.client.push
 
 import com.jraska.github.client.Config
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsProperty
 import com.jraska.github.client.common.BooleanResult
 import com.jraska.github.client.common.BooleanResult.FAILURE
@@ -13,7 +14,7 @@ internal class ConfigAsPropertyCommand @Inject constructor(
   override fun execute(action: PushAction): BooleanResult {
     val key = action.parameters["config_key"] ?: return FAILURE
 
-    val value = config.getString(key)
+    val value = config.getString(Config.Key(key, Owner.UNKNOWN))
     analyticsProperty.setUserProperty(key, value)
     return BooleanResult.SUCCESS
   }

--- a/feature/push/src/main/java/com/jraska/github/client/push/PushAnalytics.kt
+++ b/feature/push/src/main/java/com/jraska/github/client/push/PushAnalytics.kt
@@ -1,5 +1,6 @@
 package com.jraska.github.client.push
 
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import com.jraska.github.client.common.BooleanResult
@@ -11,7 +12,7 @@ internal class PushAnalytics @Inject constructor(
   private val eventAnalytics: EventAnalytics
 ) {
   fun onTokenRefresh() {
-    val tokenEvent = AnalyticsEvent.builder("push_token_refresh")
+    val tokenEvent = AnalyticsEvent.builder(ANALYTICS_PUSH_TOKEN_REFRESH)
       .addProperty("session_id", identityProvider.session().id.toString())
       .build()
     eventAnalytics.report(tokenEvent)
@@ -19,15 +20,21 @@ internal class PushAnalytics @Inject constructor(
 
   fun onPushHandled(action: PushAction, result: BooleanResult) {
     if (result == BooleanResult.SUCCESS) {
-      val pushHandled = AnalyticsEvent.builder("push_handled")
+      val pushHandled = AnalyticsEvent.builder(ANALYTICS_PUSH_HANDLED)
         .addProperty("push_action", action.name)
         .build()
       eventAnalytics.report(pushHandled)
     } else {
-      val pushHandled = AnalyticsEvent.builder("push_not_handled")
+      val pushHandled = AnalyticsEvent.builder(ANALYTICS_PUSH_NOT_HANDLED)
         .addProperty("push_action", action.name)
         .build()
       eventAnalytics.report(pushHandled)
     }
+  }
+
+  companion object {
+    val ANALYTICS_PUSH_TOKEN_REFRESH = AnalyticsEvent.Key("push_token_refresh", Owner.CORE_TEAM)
+    val ANALYTICS_PUSH_HANDLED = AnalyticsEvent.Key("push_handled", Owner.CORE_TEAM)
+    val ANALYTICS_PUSH_NOT_HANDLED = AnalyticsEvent.Key("push_not_handled", Owner.CORE_TEAM)
   }
 }

--- a/feature/settings/src/main/java/com/jraska/github/client/settings/SettingsViewModel.kt
+++ b/feature/settings/src/main/java/com/jraska/github/client/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.jraska.github.client.settings
 
 import androidx.lifecycle.ViewModel
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import javax.inject.Inject
@@ -12,11 +13,15 @@ constructor(
   fun onPurchaseSubmitted(value: String) {
     val money = value.toDoubleOrNull() ?: return
 
-    val event = AnalyticsEvent.builder("ecommerce_purchase")
+    val event = AnalyticsEvent.builder(ANALYTICS_ECOMMERCE_PURCHASE)
       .addProperty("value", money)
       .addProperty("currency", "USD")
       .build()
 
     eventAnalytics.report(event)
+  }
+
+  companion object {
+    val ANALYTICS_ECOMMERCE_PURCHASE = AnalyticsEvent.Key("ecommerce_purchase", Owner.USERS_TEAM)
   }
 }

--- a/feature/shortcuts/src/main/java/com/jraska/github/client/shortcuts/ShortcutHandlerModel.kt
+++ b/feature/shortcuts/src/main/java/com/jraska/github/client/shortcuts/ShortcutHandlerModel.kt
@@ -2,6 +2,7 @@ package com.jraska.github.client.shortcuts
 
 import androidx.lifecycle.ViewModel
 import com.jraska.github.client.DeepLinkHandler
+import com.jraska.github.client.Owner
 
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
@@ -15,12 +16,16 @@ internal class ShortcutHandlerModel @Inject constructor(
 ) : ViewModel() {
 
   internal fun handleDeepLink(url: HttpUrl) {
-    val event = AnalyticsEvent.builder("shortcut_clicked")
+    val event = AnalyticsEvent.builder(ANALYTICS_SHORTCUT_CLICKED)
       .addProperty("shortcut", url.toString())
       .build()
 
     eventAnalytics.report(event)
 
     deepLinkHandler.handleDeepLink(url)
+  }
+
+  companion object {
+    val ANALYTICS_SHORTCUT_CLICKED = AnalyticsEvent.Key("shortcut_clicked", Owner.USERS_TEAM)
   }
 }

--- a/feature/users/src/main/java/com/jraska/github/client/users/UserDetailViewModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/UserDetailViewModel.kt
@@ -3,6 +3,7 @@ package com.jraska.github.client.users
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.jraska.github.client.Config
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import com.jraska.github.client.common.lazyMap
@@ -30,7 +31,7 @@ internal class UserDetailViewModel @Inject constructor(
   }
 
   private fun createUserLiveData(login: String): LiveData<ViewState> {
-    var reposInSection = config.getLong("user_detail_section_size").toInt()
+    var reposInSection = config.getLong(USER_DETAIL_SECTION_SIZE_KEY).toInt()
     if (reposInSection <= 0) {
       reposInSection = 5
     }
@@ -45,7 +46,7 @@ internal class UserDetailViewModel @Inject constructor(
   }
 
   fun onUserGitHubIconClick(login: String) {
-    val event = AnalyticsEvent.builder("open_github_from_detail")
+    val event = AnalyticsEvent.builder(ANALYTICS_OPEN_GITHUB)
       .addProperty("login", login)
       .build()
 
@@ -55,7 +56,7 @@ internal class UserDetailViewModel @Inject constructor(
   }
 
   fun onRepoClicked(header: RepoHeader) {
-    val event = AnalyticsEvent.builder("open_repo_from_detail")
+    val event = AnalyticsEvent.builder(ANALYTICS_OPEN_REPO)
       .addProperty("owner", header.owner)
       .addProperty("name", header.name)
       .build()
@@ -69,5 +70,11 @@ internal class UserDetailViewModel @Inject constructor(
     object Loading : ViewState()
     class Error(val error: Throwable) : ViewState()
     class DisplayUser(val user: UserDetail) : ViewState()
+  }
+
+  companion object {
+    val USER_DETAIL_SECTION_SIZE_KEY = Config.Key("user_detail_section_size", Owner.USERS_TEAM)
+    val ANALYTICS_OPEN_GITHUB = AnalyticsEvent.Key("open_github_from_detail", Owner.USERS_TEAM)
+    val ANALYTICS_OPEN_REPO = AnalyticsEvent.Key("open_repo_from_detail", Owner.USERS_TEAM)
   }
 }

--- a/feature/users/src/main/java/com/jraska/github/client/users/UsersViewModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/UsersViewModel.kt
@@ -2,6 +2,7 @@ package com.jraska.github.client.users
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import com.jraska.github.client.core.android.rx.toLiveData
@@ -45,7 +46,7 @@ internal class UsersViewModel @Inject constructor(
   }
 
   fun onUserClicked(user: User) {
-    val event = AnalyticsEvent.builder("open_user_detail")
+    val event = AnalyticsEvent.builder(ANALYTICS_OPEN_USER)
       .addProperty("login", user.login)
       .build()
 
@@ -55,7 +56,7 @@ internal class UsersViewModel @Inject constructor(
   }
 
   fun onUserGitHubIconClicked(user: User) {
-    val event = AnalyticsEvent.builder("open_github_from_list")
+    val event = AnalyticsEvent.builder(ANALYTICS_OPEN_GITHUB)
       .addProperty("login", user.login)
       .build()
 
@@ -65,13 +66,13 @@ internal class UsersViewModel @Inject constructor(
   }
 
   fun onSettingsIconClicked() {
-    eventAnalytics.report(AnalyticsEvent.create("open_settings_from_list"))
+    eventAnalytics.report(AnalyticsEvent.create(ANALYTICS_OPEN_SETTINGS))
 
     navigator.showSettings()
   }
 
   fun onAboutIconClicked() {
-    eventAnalytics.report(AnalyticsEvent.create("open_about_from_list"))
+    eventAnalytics.report(AnalyticsEvent.create(ANALYTICS_OPEN_ABOUT))
 
     navigator.showAbout()
   }
@@ -80,5 +81,12 @@ internal class UsersViewModel @Inject constructor(
     object Loading : ViewState()
     class Error(val error: Throwable) : ViewState()
     class ShowUsers(val users: List<User>) : ViewState()
+  }
+
+  companion object {
+    val ANALYTICS_OPEN_USER = AnalyticsEvent.Key("open_user_detail", Owner.USERS_TEAM)
+    val ANALYTICS_OPEN_GITHUB = AnalyticsEvent.Key("open_github_from_list", Owner.USERS_TEAM)
+    val ANALYTICS_OPEN_SETTINGS = AnalyticsEvent.Key("open_settings_from_list", Owner.USERS_TEAM)
+    val ANALYTICS_OPEN_ABOUT = AnalyticsEvent.Key("open_about_from_list", Owner.USERS_TEAM)
   }
 }

--- a/feature/users/src/main/java/com/jraska/github/client/users/model/RepoDetailViewModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/model/RepoDetailViewModel.kt
@@ -4,6 +4,7 @@ import android.view.View
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.google.android.material.snackbar.Snackbar
+import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
 import com.jraska.github.client.common.lazyMap
@@ -42,7 +43,7 @@ internal class RepoDetailViewModel @Inject constructor(
   }
 
   fun onGitHubIconClicked(fullRepoName: String) {
-    val event = AnalyticsEvent.builder("open_repo_from_detail")
+    val event = AnalyticsEvent.builder(ANALYTICS_OPEN_REPO)
       .addProperty("owner", RepoHeader.name(fullRepoName))
       .addProperty("name", RepoHeader.name(fullRepoName))
       .build()
@@ -63,5 +64,9 @@ internal class RepoDetailViewModel @Inject constructor(
     object Loading : ViewState()
     class Error(val error: Throwable) : ViewState()
     class ShowRepo(val repo: RepoDetail) : ViewState()
+  }
+
+  companion object {
+    val ANALYTICS_OPEN_REPO = AnalyticsEvent.Key("open_repo_from_detail", Owner.USERS_TEAM)
   }
 }


### PR DESCRIPTION
# Problem being solved
- Ownership of config and analytics is not clear after some time passes.
- We need to know if these keys are still used or not - they are usually used in external system and there is no visibility on this in code.
- Config and analytics names can be scattered around the code.

# The solution
- Ownership configuration is moved into code and is enforced by config and analytics API
- Enforcing same format of introducing keys - no discussion of constant/not constant.
- Configs and analytics keys are easily searchable - see screenshot

Analytics Keys with owners         |  Config Keys with owners
:----:|:----:
<img width="808" alt="Screenshot 2020-05-03 at 15 57 44" src="https://user-images.githubusercontent.com/6277721/80916085-db0d3080-8d56-11ea-9735-9590eb12bc0c.png">|<img width="735" alt="Screenshot 2020-05-03 at 15 59 15" src="https://user-images.githubusercontent.com/6277721/80916146-3b03d700-8d57-11ea-829e-1fece3aedf2f.png">

When searching for constructor, we can export our keys like into something like this:
[analytics.txt](https://github.com/jraska/github-client/files/4570601/analytics.txt)





