### PR TITLE
Catch exceptions during build time reporting

### DIFF
--- a/plugins/src/main/java/com/jraska/gradle/buildtime/report/MixpanelReporter.kt
+++ b/plugins/src/main/java/com/jraska/gradle/buildtime/report/MixpanelReporter.kt
@@ -13,6 +13,14 @@ class MixpanelReporter(
   private val api: MixpanelAPI
 ) : BuildReporter {
   override fun report(buildData: BuildData) {
+    try {
+      reportToMixpanel(buildData)
+    } catch (ex: Exception) {
+      println("Build time reporting failed: $ex")
+    }
+  }
+
+  private fun reportToMixpanel(buildData: BuildData) {
     val start = nowMillis()
 
     reportInternal(buildData)


### PR DESCRIPTION
- Prevents build failures on reporting
- Relates to #303 