### PR TITLE
Remove usage of deprecated Kotlin generated view synthetics

### DIFF
--- a/app-partial-users/build.gradle
+++ b/app-partial-users/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,6 @@ plugins {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 if (project.hasProperty("enable-performance-plugin")) {
   apply plugin: 'com.google.firebase.firebase-perf'

--- a/feature/about/build.gradle
+++ b/feature/about/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/feature/about/src/main/java/com/jraska/github/client/about/AboutActivity.kt
+++ b/feature/about/src/main/java/com/jraska/github/client/about/AboutActivity.kt
@@ -4,12 +4,11 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
-import kotlinx.android.synthetic.main.activity_about.toolbar
-import kotlinx.android.synthetic.main.content_about.about_recycler
 
 internal class AboutActivity : BaseActivity() {
 
@@ -18,7 +17,7 @@ internal class AboutActivity : BaseActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_about)
-    setSupportActionBar(toolbar)
+    setSupportActionBar(findViewById(R.id.toolbar))
 
     val spansCount = 2
     val epoxyAdapter = SimpleEpoxyAdapter()
@@ -28,8 +27,9 @@ internal class AboutActivity : BaseActivity() {
     val layoutManager = GridLayoutManager(this, spansCount)
     layoutManager.spanSizeLookup = epoxyAdapter.spanSizeLookup
 
-    about_recycler.layoutManager = layoutManager
-    about_recycler.adapter = epoxyAdapter
+    val aboutRecycler = findViewById<RecyclerView>(R.id.about_recycler)
+    aboutRecycler.layoutManager = layoutManager
+    aboutRecycler.adapter = epoxyAdapter
   }
 
   private fun createModels(): List<EpoxyModel<*>>? {

--- a/feature/about/src/main/java/com/jraska/github/client/about/IconModel.kt
+++ b/feature/about/src/main/java/com/jraska/github/client/about/IconModel.kt
@@ -1,10 +1,10 @@
 package com.jraska.github.client.about
 
 import android.view.View
+import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import com.airbnb.epoxy.SimpleEpoxyModel
-import kotlinx.android.synthetic.main.about_item_icon.view.about_item_icon
 
 internal class IconModel(
   private val clickListener: () -> Unit,
@@ -17,8 +17,9 @@ internal class IconModel(
 
     view.setOnClickListener { clickListener() }
 
-    view.about_item_icon.setImageResource(iconRes)
-    view.about_item_icon.contentDescription = view.context.getString(contentDescriptionRes)
+    val aboutItemIcon = view.findViewById<ImageView>(R.id.about_item_icon)
+    aboutItemIcon.setImageResource(iconRes)
+    aboutItemIcon.contentDescription = view.context.getString(contentDescriptionRes)
   }
 
   override fun getSpanSize(totalSpanCount: Int, position: Int, itemCount: Int): Int {

--- a/feature/settings/build.gradle
+++ b/feature/settings/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
-apply plugin: 'kotlin-android-extensions'
 
 android {
   compileSdkVersion 30

--- a/feature/settings/src/main/java/com/jraska/github/client/settings/PurchaseReportModel.kt
+++ b/feature/settings/src/main/java/com/jraska/github/client/settings/PurchaseReportModel.kt
@@ -1,19 +1,17 @@
 package com.jraska.github.client.settings
 
 import android.view.View
+import android.widget.TextView
 import com.airbnb.epoxy.EpoxyModel
-import kotlinx.android.synthetic.main.item_row_purchase.view.settings_purchase_input
-import kotlinx.android.synthetic.main.item_row_purchase.view.settings_purchase_submit_button
 
-internal class PurchaseReportModel(private val onPurchaseClicked: (String) -> Unit)
-  : EpoxyModel<View>() {
+internal class PurchaseReportModel(private val onPurchaseClicked: (String) -> Unit) : EpoxyModel<View>() {
   override fun getDefaultLayout(): Int {
     return R.layout.item_row_purchase
   }
 
   override fun bind(itemView: View) {
-    itemView.settings_purchase_submit_button.setOnClickListener {
-      val valueEntered = itemView.settings_purchase_input.text.toString()
+    itemView.findViewById<View>(R.id.settings_purchase_submit_button).setOnClickListener {
+      val valueEntered = itemView.findViewById<TextView>(R.id.settings_purchase_input).text.toString()
       onPurchaseClicked(valueEntered)
     }
   }

--- a/feature/settings/src/main/java/com/jraska/github/client/settings/SettingsActivity.kt
+++ b/feature/settings/src/main/java/com/jraska/github/client/settings/SettingsActivity.kt
@@ -4,11 +4,10 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
-import kotlinx.android.synthetic.main.activity_settings.toolbar
-import kotlinx.android.synthetic.main.content_settings.settings_recycler
 
 internal class SettingsActivity : BaseActivity() {
   private val viewModel: SettingsViewModel by lazy { viewModel(SettingsViewModel::class.java) }
@@ -16,13 +15,14 @@ internal class SettingsActivity : BaseActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_settings)
-    setSupportActionBar(toolbar)
+    setSupportActionBar(findViewById(R.id.toolbar))
 
-    settings_recycler.layoutManager = LinearLayoutManager(this)
+    val settingsRecycler = findViewById<RecyclerView>(R.id.settings_recycler)
+    settingsRecycler.layoutManager = LinearLayoutManager(this)
     val adapter = SimpleEpoxyAdapter()
     adapter.addModels(PurchaseReportModel(this::onPurchaseButtonClicked))
     adapter.addModels(ConsoleModel())
-    settings_recycler.adapter = adapter
+    settingsRecycler.adapter = adapter
   }
 
   private fun onPurchaseButtonClicked(value: String) {

--- a/feature/shortcuts/build.gradle
+++ b/feature/shortcuts/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/feature/users/build.gradle
+++ b/feature/users/build.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/RepoDetailActivity.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/RepoDetailActivity.kt
@@ -3,22 +3,22 @@ package com.jraska.github.client.users.ui
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
-import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.airbnb.epoxy.SimpleEpoxyModel
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.model.RepoDetail
 import com.jraska.github.client.users.model.RepoDetailViewModel
-import kotlinx.android.synthetic.main.activity_repo_detail.repo_detail_github_fab
-import kotlinx.android.synthetic.main.activity_repo_detail.toolbar
-import kotlinx.android.synthetic.main.content_repo_detail.repo_detail_recycler
 
 internal class RepoDetailActivity : BaseActivity() {
 
   private val viewModel: RepoDetailViewModel by lazy { viewModel(RepoDetailViewModel::class.java) }
+
+  private val repoDetailRecycler: RecyclerView get() = findViewById(R.id.repo_detail_recycler)
 
   private fun fullRepoName(): String {
     return intent.getStringExtra(EXTRA_FULL_REPO_NAME)!!
@@ -28,15 +28,16 @@ internal class RepoDetailActivity : BaseActivity() {
     super.onCreate(savedInstanceState)
 
     setContentView(R.layout.activity_repo_detail)
-    setSupportActionBar(toolbar)
-    repo_detail_recycler.layoutManager = LinearLayoutManager(this)
+    setSupportActionBar(findViewById(R.id.toolbar))
+    repoDetailRecycler.layoutManager = LinearLayoutManager(this)
 
     title = fullRepoName()
 
     val liveData = viewModel.repoDetail(fullRepoName())
-    liveData.observe(this, Observer { this.setState(it) })
+    liveData.observe(this, { this.setState(it) })
 
-    repo_detail_github_fab.setOnClickListener { viewModel.onGitHubIconClicked(fullRepoName()) }
+    findViewById<FloatingActionButton>(R.id.repo_detail_github_fab)
+      .setOnClickListener { viewModel.onGitHubIconClicked(fullRepoName()) }
   }
 
   private fun setState(state: RepoDetailViewModel.ViewState) {
@@ -48,11 +49,11 @@ internal class RepoDetailActivity : BaseActivity() {
   }
 
   private fun showLoading() {
-    repo_detail_recycler.adapter = SimpleEpoxyAdapter().apply { addModels(SimpleEpoxyModel(R.layout.item_loading)) }
+    findViewById<RecyclerView>(R.id.repo_detail_recycler).adapter = SimpleEpoxyAdapter().apply { addModels(SimpleEpoxyModel(R.layout.item_loading)) }
   }
 
   private fun setError(error: Throwable) {
-    ErrorHandler.displayError(error, repo_detail_recycler)
+    ErrorHandler.displayError(error, repoDetailRecycler)
   }
 
   private fun setRepoDetail(repoDetail: RepoDetail) {
@@ -71,7 +72,7 @@ internal class RepoDetailActivity : BaseActivity() {
     )
     adapter.addModels(SimpleTextModel(issuesText))
 
-    repo_detail_recycler.adapter = adapter
+    repoDetailRecycler.adapter = adapter
   }
 
   companion object {

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/RepoDetailHeaderModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/RepoDetailHeaderModel.kt
@@ -1,17 +1,13 @@
 package com.jraska.github.client.users.ui
 
 import android.view.View
+import android.widget.TextView
 import com.airbnb.epoxy.EpoxyModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.model.RepoDetail
-import kotlinx.android.synthetic.main.item_repo_detail_stats.view.repo_detail_created
-import kotlinx.android.synthetic.main.item_repo_detail_stats.view.repo_detail_forks_count
-import kotlinx.android.synthetic.main.item_repo_detail_stats.view.repo_detail_stars_count
-import kotlinx.android.synthetic.main.item_repo_detail_stats.view.repo_detail_subscribers_count
 import org.threeten.bp.format.DateTimeFormatter
 
-internal class RepoDetailHeaderModel(private val repoDetail: RepoDetail)
-  : EpoxyModel<View>() {
+internal class RepoDetailHeaderModel(private val repoDetail: RepoDetail) : EpoxyModel<View>() {
 
   override fun getDefaultLayout(): Int {
     return R.layout.item_repo_detail_stats
@@ -19,11 +15,11 @@ internal class RepoDetailHeaderModel(private val repoDetail: RepoDetail)
 
   override fun bind(itemView: View) {
     val createdText = CREATED_DATE_FORMAT.format(repoDetail.data.created)
-    itemView.repo_detail_created.text = createdText
+    itemView.findViewById<TextView>(R.id.repo_detail_created).text = createdText
 
-    itemView.repo_detail_subscribers_count.text = repoDetail.data.subscribersCount.toString()
-    itemView.repo_detail_forks_count.text = repoDetail.header.forks.toString()
-    itemView.repo_detail_stars_count.text = repoDetail.header.stars.toString()
+    itemView.findViewById<TextView>(R.id.repo_detail_subscribers_count).text = repoDetail.data.subscribersCount.toString()
+    itemView.findViewById<TextView>(R.id.repo_detail_forks_count).text = repoDetail.header.forks.toString()
+    itemView.findViewById<TextView>(R.id.repo_detail_stars_count).text = repoDetail.header.stars.toString()
   }
 
   companion object {

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/RepoHeaderModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/RepoHeaderModel.kt
@@ -1,13 +1,10 @@
 package com.jraska.github.client.users.ui
 
 import android.view.View
+import android.widget.TextView
 import com.airbnb.epoxy.EpoxyModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.model.RepoHeader
-import kotlinx.android.synthetic.main.item_row_user_detail_repo.view.repo_item_description
-import kotlinx.android.synthetic.main.item_row_user_detail_repo.view.repo_item_forks
-import kotlinx.android.synthetic.main.item_row_user_detail_repo.view.repo_item_stars
-import kotlinx.android.synthetic.main.item_row_user_detail_repo.view.repo_item_title
 
 internal class RepoHeaderModel(
   private val repo: RepoHeader,
@@ -18,10 +15,10 @@ internal class RepoHeaderModel(
   }
 
   override fun bind(itemView: View) {
-    itemView.repo_item_title.text = repo.name
-    itemView.repo_item_description.text = repo.description
-    itemView.repo_item_stars.text = repo.stars.toString()
-    itemView.repo_item_forks.text = repo.forks.toString()
+    itemView.findViewById<TextView>(R.id.repo_item_title).text = repo.name
+    itemView.findViewById<TextView>(R.id.repo_item_description).text = repo.description
+    itemView.findViewById<TextView>(R.id.repo_item_stars).text = repo.stars.toString()
+    itemView.findViewById<TextView>(R.id.repo_item_forks).text = repo.forks.toString()
 
     itemView.setOnClickListener { repoListener(repo) }
   }

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/ReposSectionModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/ReposSectionModel.kt
@@ -1,12 +1,12 @@
 package com.jraska.github.client.users.ui
 
 import android.view.View
+import android.widget.TextView
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.model.RepoHeader
-import kotlinx.android.synthetic.main.item_repos_section.view.repos_repeater
-import kotlinx.android.synthetic.main.item_repos_section.view.repos_title
+import com.jraska.github.client.users.widget.RepeaterLayout
 
 internal class ReposSectionModel(
   private val title: String,
@@ -19,11 +19,11 @@ internal class ReposSectionModel(
   }
 
   override fun bind(itemView: View) {
-    itemView.repos_title.text = title
+    itemView.findViewById<TextView>(R.id.repos_title).text = title
 
     val adapter = SimpleEpoxyAdapter()
     adapter.addModels(repos.map { repo -> RepoHeaderModel(repo, repoListener) })
 
-    itemView.repos_repeater.setAdapter(adapter)
+    itemView.findViewById<RepeaterLayout>(R.id.repos_repeater).setAdapter(adapter)
   }
 }

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/UserDetailActivity.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/UserDetailActivity.kt
@@ -5,19 +5,18 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.airbnb.epoxy.SimpleEpoxyModel
+import com.facebook.drawee.view.SimpleDraweeView
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.UserDetailViewModel
 import com.jraska.github.client.users.model.RepoHeader
 import com.jraska.github.client.users.model.UserDetail
-import kotlinx.android.synthetic.main.activity_user_detail.toolbar
-import kotlinx.android.synthetic.main.activity_user_detail.user_detail_avatar
-import kotlinx.android.synthetic.main.activity_user_detail.user_detail_github_fab
-import kotlinx.android.synthetic.main.content_user_detail.user_detail_recycler
 
 internal class UserDetailActivity : BaseActivity() {
 
@@ -30,17 +29,18 @@ internal class UserDetailActivity : BaseActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_user_detail)
-    setSupportActionBar(toolbar)
+    setSupportActionBar(findViewById(R.id.toolbar))
 
-    user_detail_recycler.layoutManager = LinearLayoutManager(this)
-    user_detail_recycler.isNestedScrollingEnabled = false
+    val userDetailRecycler = findViewById<RecyclerView>(R.id.user_detail_recycler)
+    userDetailRecycler.layoutManager = LinearLayoutManager(this)
+    userDetailRecycler.isNestedScrollingEnabled = false
 
     title = login()
 
     val detailLiveData = userDetailViewModel.userDetail(login())
-    detailLiveData.observe(this, Observer { this.setState(it) })
+    detailLiveData.observe(this, { this.setState(it) })
 
-    user_detail_github_fab.setOnClickListener { userDetailViewModel.onUserGitHubIconClick(login()) }
+    findViewById<FloatingActionButton>(R.id.user_detail_github_fab).setOnClickListener { userDetailViewModel.onUserGitHubIconClick(login()) }
   }
 
   private fun setState(state: UserDetailViewModel.ViewState) {
@@ -52,7 +52,7 @@ internal class UserDetailActivity : BaseActivity() {
   }
 
   private fun setUser(userDetail: UserDetail) {
-    user_detail_avatar.setImageURI(userDetail.user.avatarUrl)
+    findViewById<SimpleDraweeView>(R.id.user_detail_avatar).setImageURI(userDetail.user.avatarUrl)
 
     if (userDetail.basicStats == null) {
       return
@@ -79,15 +79,15 @@ internal class UserDetailActivity : BaseActivity() {
 
     adapter.addModels(models)
 
-    user_detail_recycler.adapter = adapter
+    findViewById<RecyclerView>(R.id.user_detail_recycler).adapter = adapter
   }
 
   private fun showLoading() {
-    user_detail_recycler.adapter = SimpleEpoxyAdapter().apply { addModels(SimpleEpoxyModel(R.layout.item_loading)) }
+    findViewById<RecyclerView>(R.id.user_detail_recycler).adapter = SimpleEpoxyAdapter().apply { addModels(SimpleEpoxyModel(R.layout.item_loading)) }
   }
 
   private fun showError(error: Throwable) {
-    ErrorHandler.displayError(error, user_detail_recycler)
+    ErrorHandler.displayError(error, findViewById(R.id.user_detail_recycler))
   }
 
   private fun onRepoClicked(header: RepoHeader) {

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/UserHeaderModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/UserHeaderModel.kt
@@ -1,13 +1,10 @@
 package com.jraska.github.client.users.ui
 
 import android.view.View
+import android.widget.TextView
 import com.airbnb.epoxy.EpoxyModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.model.UserStats
-import kotlinx.android.synthetic.main.item_user_stats.view.user_detail_followers_count
-import kotlinx.android.synthetic.main.item_user_stats.view.user_detail_following_count
-import kotlinx.android.synthetic.main.item_user_stats.view.user_detail_joined
-import kotlinx.android.synthetic.main.item_user_stats.view.user_detail_repos_count
 import org.threeten.bp.format.DateTimeFormatter
 
 internal class UserHeaderModel(private val basicStats: UserStats) : EpoxyModel<View>() {
@@ -17,14 +14,14 @@ internal class UserHeaderModel(private val basicStats: UserStats) : EpoxyModel<V
   }
 
   override fun bind(itemView: View) {
-    itemView.user_detail_followers_count.text = basicStats.followers.toString()
-    itemView.user_detail_following_count.text = basicStats.following.toString()
-    itemView.user_detail_repos_count.text = basicStats.publicRepos.toString()
+    itemView.findViewById<TextView>(R.id.user_detail_followers_count).text = basicStats.followers.toString()
+    itemView.findViewById<TextView>(R.id.user_detail_following_count).text = basicStats.following.toString()
+    itemView.findViewById<TextView>(R.id.user_detail_repos_count).text = basicStats.publicRepos.toString()
 
     val joinedDateText = JOINED_FORMAT.format(basicStats.joined)
     val joinedText = itemView.context
       .getString(R.string.user_detail_joined_template, joinedDateText)
-    itemView.user_detail_joined.text = joinedText
+    itemView.findViewById<TextView>(R.id.user_detail_joined).text = joinedText
   }
 
   companion object {

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/UserModel.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/UserModel.kt
@@ -1,27 +1,24 @@
 package com.jraska.github.client.users.ui
 
 import android.view.View
+import android.widget.TextView
 import com.airbnb.epoxy.EpoxyModel
+import com.facebook.drawee.view.SimpleDraweeView
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.model.User
-import kotlinx.android.synthetic.main.item_row_user.view.user_admin_image
-import kotlinx.android.synthetic.main.item_row_user.view.user_avatar
-import kotlinx.android.synthetic.main.item_row_user.view.user_container
-import kotlinx.android.synthetic.main.item_row_user.view.user_item_gitHub_icon
-import kotlinx.android.synthetic.main.item_row_user.view.user_login
 
 internal class UserModel(private val user: User, private val userListener: UserListener) : EpoxyModel<View>() {
 
   override fun bind(itemView: View) {
-    itemView.user_login.text = user.login
-    itemView.user_avatar.setImageURI(user.avatarUrl)
-    itemView.user_admin_image.visibility = if (user.isAdmin) {
+    itemView.findViewById<TextView>(R.id.user_login).text = user.login
+    itemView.findViewById<SimpleDraweeView>(R.id.user_avatar).setImageURI(user.avatarUrl)
+    itemView.findViewById<View>(R.id.user_admin_image).visibility = if (user.isAdmin) {
       View.VISIBLE
     } else {
       View.GONE
     }
-    itemView.user_item_gitHub_icon.setOnClickListener { userListener.onUserGitHubIconClicked(user) }
-    itemView.user_container.setOnClickListener { userListener.onUserClicked(user) }
+    itemView.findViewById<View>(R.id.user_item_gitHub_icon).setOnClickListener { userListener.onUserGitHubIconClicked(user) }
+    itemView.findViewById<View>(R.id.user_container).setOnClickListener { userListener.onUserClicked(user) }
   }
 
   override fun getDefaultLayout(): Int {

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/UsersActivity.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/UsersActivity.kt
@@ -7,30 +7,34 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.UsersViewModel
 import com.jraska.github.client.users.model.User
-import kotlinx.android.synthetic.main.activity_users_list.toolbar
-import kotlinx.android.synthetic.main.content_users_list.users_recycler
-import kotlinx.android.synthetic.main.content_users_list.users_refresh_swipe_layout
 
 class UsersActivity : BaseActivity(), UserModel.UserListener {
   private val usersViewModel: UsersViewModel by lazy { viewModel(UsersViewModel::class.java) }
 
+  private val usersRecycler: RecyclerView get() = findViewById(R.id.users_recycler)
+  private val usersRefreshSwipeLayout: SwipeRefreshLayout get() = findViewById(R.id.users_refresh_swipe_layout)
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_users_list)
-    setSupportActionBar(toolbar)
+    setSupportActionBar(findViewById(R.id.toolbar))
 
-    users_recycler.layoutManager = LinearLayoutManager(this)
-    users_refresh_swipe_layout.setOnRefreshListener { usersViewModel.onRefresh() }
+    usersRecycler.layoutManager = LinearLayoutManager(this)
+    usersRefreshSwipeLayout.setOnRefreshListener { usersViewModel.onRefresh() }
+
+    packageManager.getPackageInfo(packageName, 0)
 
     showProgressIndicator()
 
-    usersViewModel.users().observe(this, Observer { this.setState(it) })
+    usersViewModel.users().observe(this, { this.setState(it) })
   }
 
   override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -79,29 +83,29 @@ class UsersActivity : BaseActivity(), UserModel.UserListener {
     val models = users.map { user -> UserModel(user, this) }
 
     adapter.addModels(models)
-    users_recycler.adapter = adapter
+    usersRecycler.adapter = adapter
   }
 
   private fun showError(error: Throwable) {
-    ErrorHandler.displayError(error, users_recycler)
+    ErrorHandler.displayError(error, usersRecycler)
   }
 
   private fun showProgressIndicator() {
     ensureProgressIndicatorVisible()
 
-    users_refresh_swipe_layout.isRefreshing = true
+    usersRefreshSwipeLayout.isRefreshing = true
   }
 
   private fun hideProgressIndicator() {
-    users_refresh_swipe_layout.isRefreshing = false
+    usersRefreshSwipeLayout.isRefreshing = false
   }
 
   private fun ensureProgressIndicatorVisible() {
     // Workaround for start progress called before onMeasure
     // Issue: https://code.google.com/p/android/issues/detail?id=77712
-    if (users_refresh_swipe_layout.measuredHeight == 0) {
+    if (usersRefreshSwipeLayout.measuredHeight == 0) {
       val circleSize = resources.getDimensionPixelSize(R.dimen.swipe_progress_circle_diameter)
-      users_refresh_swipe_layout.setProgressViewOffset(false, 0, circleSize)
+      usersRefreshSwipeLayout.setProgressViewOffset(false, 0, circleSize)
     }
   }
 


### PR DESCRIPTION
- Removing the plugin as we don't use Parcelable and the rest was deprecated.
- https://youtrack.jetbrains.com/issue/KT-42121