### PR TITLE
Rely on embedded gcloud on circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,7 @@ jobs:
           command: ./gradlew check --stacktrace --max-workers=2 --no-daemon
       - run:
           name: Run Tests Firebase
-          command: mkdir ~/gcloud
-            && curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-291.0.0-linux-x86_64.tar.gz | tar xz -C ~/gcloud
-            && echo "export PATH=~/gcloud/google-cloud-sdk/bin:$PATH" >> $BASH_ENV
-            && ./gradlew runInstrumentedTestsOnFirebase --stacktrace --no-daemon
+          command: ./gradlew runInstrumentedTestsOnFirebase --stacktrace --no-daemon
       - store_artifacts:
           path: app/build/reports
           destination: app/reports


### PR DESCRIPTION
- CircleCI has embedded gcloud so we don't have to install to explicitly