### PR TITLE
Add dependency reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ workflows:
   check:
     jobs:
       - build
+      - moduleStatisticsReport
   statisticsReport:
     triggers:
       - schedule:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           key: cache-{{ checksum "build.gradle" }}-{{ checksum  "dependencies.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
           name: Execute Data Processing
-          command: ./gradlew reportModuleStatistics --max-workers=2 --stacktrace
+          command: ./gradlew reportModuleStatistics --max-workers=2 --stacktrace --no-configure-on-demand
       - save_cache:
           paths:
             - ~/.gradle

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ workflows:
   check:
     jobs:
       - build
-      - moduleStatisticsReport
   statisticsReport:
     triggers:
       - schedule:

--- a/plugins/src/main/java/com/jraska/gradle/buildtime/BuildReporter.kt
+++ b/plugins/src/main/java/com/jraska/gradle/buildtime/BuildReporter.kt
@@ -26,8 +26,6 @@ class BuildReporter(
   }
 
   private fun reportInternal(buildData: BuildData) {
-    val delivery = ClientDelivery()
-
     val properties = convertBuildData(buildData)
     val event = AnalyticsEvent("Android Build", properties)
     analyticsReporter.report(event)

--- a/plugins/src/main/java/com/jraska/module/ModuleStatistics.kt
+++ b/plugins/src/main/java/com/jraska/module/ModuleStatistics.kt
@@ -33,8 +33,15 @@ data class ModuleArtifactDependency(
   val group: String,
   val artifact: String,
   val version: String?,
-  val configurationName: String
+  val dependencyType: ArtifactDependencyType
 )
+
+enum class ArtifactDependencyType {
+  Compile,
+  Test,
+  AndroidTest,
+  Kapt
+}
 
 enum class ModuleType {
   Api,

--- a/plugins/src/main/java/com/jraska/module/ModuleStatistics.kt
+++ b/plugins/src/main/java/com/jraska/module/ModuleStatistics.kt
@@ -9,6 +9,7 @@ data class ProjectStatistics(
   val prodJavaTotalLines: Int,
   val prodXmlTotalLines: Int,
   val moduleStatistics: List<ModuleStatistics>,
+  val externalDependencies: List<ModuleArtifactDependency>
 )
 
 data class ModuleStatistics(
@@ -23,6 +24,16 @@ data class FileTypeStatistics(
   val lineCount: Int,
   val fileCount: Int,
   val type: FileType
+)
+
+data class ModuleArtifactDependency(
+  val moduleName: String,
+  val type: ModuleType,
+  val fullName: String,
+  val group: String,
+  val artifact: String,
+  val version: String?,
+  val configurationName: String
 )
 
 enum class ModuleType {

--- a/plugins/src/main/java/com/jraska/module/ModuleStatsReporter.kt
+++ b/plugins/src/main/java/com/jraska/module/ModuleStatsReporter.kt
@@ -76,7 +76,7 @@ class ModuleStatsReporter(
       "artifactId" to artifactDependency.artifact,
       "version" to artifactDependency.version,
       "fullComponentName" to artifactDependency.fullName,
-      "configurationName" to artifactDependency.configurationName
+      "dependencyType" to artifactDependency.dependencyType
     )
   }
 

--- a/plugins/src/main/java/com/jraska/module/ModuleStatsReporter.kt
+++ b/plugins/src/main/java/com/jraska/module/ModuleStatsReporter.kt
@@ -17,6 +17,11 @@ class ModuleStatsReporter(
       events.add(AnalyticsEvent("Android Module Detail", properties))
     }
 
+    stats.externalDependencies.forEach {
+      val properties = convertModuleDependency(it)
+      events.add(AnalyticsEvent("Android Module External Dependency", properties))
+    }
+
     analyticsReporter.report(*events.toTypedArray())
 
     println("$GRAPH_ICON Module stats reported to Mixpanel $GRAPH_ICON")
@@ -61,6 +66,18 @@ class ModuleStatsReporter(
       FileType.JAVA -> "Java"
       FileType.XML -> "Xml"
     }
+  }
+
+  private fun convertModuleDependency(artifactDependency: ModuleArtifactDependency): Map<String, Any?> {
+    return mapOf<String, Any?>(
+      "moduleName" to artifactDependency.moduleName,
+      "moduleType" to artifactDependency.type.name,
+      "groupId" to artifactDependency.group,
+      "artifactId" to artifactDependency.artifact,
+      "version" to artifactDependency.version,
+      "fullComponentName" to artifactDependency.fullName,
+      "configurationName" to artifactDependency.configurationName
+    )
   }
 
   companion object {

--- a/plugins/src/main/java/com/jraska/module/extract/StatisticsGradleExtractor.kt
+++ b/plugins/src/main/java/com/jraska/module/extract/StatisticsGradleExtractor.kt
@@ -1,5 +1,6 @@
 package com.jraska.module.extract
 
+import com.jraska.module.ArtifactDependencyType
 import com.jraska.module.FileType
 import com.jraska.module.FileTypeStatistics
 import com.jraska.module.ModuleArtifactDependency
@@ -55,7 +56,7 @@ class StatisticsGradleExtractor() {
     val moduleName = module.name
 
     val dependencies = module.configurations
-      .filter { CONFIGURATION_TO_LOOK.contains(it.name) }
+      .filter { CONFIGURATION_TO_LOOK.containsKey(it.name) }
       .flatMap { configuration ->
         val projectDependencies = configuration.allDependencies.filterIsInstance(ProjectDependency::class.java)
         configuration.resolvedConfiguration.firstLevelModuleDependencies
@@ -66,7 +67,7 @@ class StatisticsGradleExtractor() {
               moduleName = moduleName,
               type = moduleType,
               group = it.moduleGroup,
-              configurationName = configuration.name,
+              dependencyType = CONFIGURATION_TO_LOOK.getValue(configuration.name),
               artifact = it.moduleName,
               version = it.moduleVersion,
               fullName = it.name
@@ -140,12 +141,14 @@ class StatisticsGradleExtractor() {
   }
 
   companion object {
-    val CONFIGURATION_TO_LOOK = setOf(
-      "debugAndroidTestCompileClasspath",
-      "debugCompileClasspath",
-      "releaseCompileClasspath",
-      "debugUnitTestCompileClasspath",
-      "kapt"
+    val CONFIGURATION_TO_LOOK = mapOf(
+      "debugAndroidTestCompileClasspath" to ArtifactDependencyType.AndroidTest,
+      "debugCompileClasspath" to ArtifactDependencyType.Compile,
+      "releaseCompileClasspath" to ArtifactDependencyType.Compile,
+      "debugUnitTestCompileClasspath" to ArtifactDependencyType.Test,
+      "compileClasspath" to ArtifactDependencyType.Compile,
+      "testCompileClasspath" to ArtifactDependencyType.Test,
+      "kapt" to ArtifactDependencyType.Kapt
     )
   }
 }

--- a/plugins/src/main/java/com/jraska/module/extract/StatisticsGradleExtractor.kt
+++ b/plugins/src/main/java/com/jraska/module/extract/StatisticsGradleExtractor.kt
@@ -2,10 +2,12 @@ package com.jraska.module.extract
 
 import com.jraska.module.FileType
 import com.jraska.module.FileTypeStatistics
+import com.jraska.module.ModuleArtifactDependency
 import com.jraska.module.ModuleStatistics
 import com.jraska.module.ModuleType
 import com.jraska.module.ProjectStatistics
 import org.gradle.api.Project
+import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency
 import java.io.BufferedReader
 import java.io.File
 import java.io.FileReader
@@ -19,12 +21,18 @@ class StatisticsGradleExtractor() {
       .filter { it.childProjects.isEmpty() }
       .map { extractFromModule(it) }
 
+    val externalDependencies = project.rootProject
+      .subprojects
+      .filter { it.childProjects.isEmpty() }
+      .flatMap { extractDependencies(it) }
+
     return ProjectStatistics(
       modulesCount = moduleStats.size,
       apiModules = moduleStats.count { it.type == ModuleType.Api },
       appModules = moduleStats.count { it.type == ModuleType.App },
       implementationModules = moduleStats.count { it.type == ModuleType.Implementation },
       moduleStatistics = moduleStats,
+      externalDependencies = externalDependencies,
       prodKotlinTotalLines = moduleStats
         .map { module -> module.containedProdFiles.single { it.type == FileType.KOTLIN }.lineCount }
         .sum(),
@@ -37,6 +45,31 @@ class StatisticsGradleExtractor() {
         .map { module -> module.containedProdFiles.single { it.type == FileType.XML }.lineCount }
         .sum()
     )
+  }
+
+  private fun extractDependencies(module: Project): List<ModuleArtifactDependency> {
+    val configurationsToLook = setOf("api", "implementation", "testImplementation", "androidTestImplementation", "kapt", "kaptAndroidTest")
+
+    val moduleType = moduleType(module)
+    val moduleName = module.name
+
+    return module.configurations
+      .filter { configurationsToLook.contains(it.name) }
+      .flatMap { configuration ->
+        configuration.dependencies
+          .filterIsInstance<DefaultExternalModuleDependency>()
+          .map {
+            ModuleArtifactDependency(
+              moduleName = moduleName,
+              type = moduleType,
+              group = it.group!!,
+              configurationName = configuration.name,
+              artifact = it.name,
+              version = it.version,
+              fullName = "${it.group}:${it.name}:${it.version}"
+            )
+          }
+      }.distinct()
   }
 
   private fun extractFromModule(module: Project): ModuleStatistics {


### PR DESCRIPTION
- Adds Dependency reporting of ll direct and transitive dependencies
- Cn be used to monitor dependency hell, track dependency removal or seeing which modules are getting bloated.
- Resolves #369 
![Screenshot 2020-12-12 at 20 59 26](https://user-images.githubusercontent.com/6277721/101994261-5ce81380-3cc1-11eb-9686-981a5d8da774.png)
![Screenshot 2020-12-12 at 21 30 15](https://user-images.githubusercontent.com/6277721/101994280-9c166480-3cc1-11eb-83ba-ee3791003f05.png)
