### PR TITLE
Align versions of plugin dependencies

### DIFF
--- a/plugins/build.gradle
+++ b/plugins/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.21"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.31"
   }
 }
 
@@ -16,11 +16,11 @@ repositories {
 
 dependencies {
   implementation gradleApi()
-  implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.21"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.31"
   implementation 'com.mixpanel:mixpanel-java:1.4.4'
 
-  testImplementation 'junit:junit:4.13.1'
-  testImplementation 'org.assertj:assertj-core:3.17.2'
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.assertj:assertj-core:3.19.0'
 }
 
 compileKotlin {


### PR DESCRIPTION
- The stuff was obsolete
- Dependabot probably doesn't see this.