### PR TITLE
Update Console to 1.2.0

### DIFF
--- a/feature/settings/build.gradle
+++ b/feature/settings/build.gradle
@@ -24,8 +24,8 @@ dependencies {
   implementation 'androidx.recyclerview:recyclerview:1.2.0'
   implementation 'com.google.android.material:material:1.3.0'
   implementation 'com.airbnb.android:epoxy:4.6.1'
-  implementation 'com.jraska:console:1.1.0'
-  implementation 'com.jraska:console-timber-tree:1.1.0'
+  implementation 'com.jraska:console:1.2.0'
+  implementation 'com.jraska:console-timber-tree:1.2.0'
   implementation rootProject.ext.okHttp
 
   implementation rootProject.ext.dagger


### PR DESCRIPTION
- Uses Maven Central now https://github.com/jraska/Console/releases/tag/1.2.0