### PR TITLE
Add OnAppCreateAsyncExecutor to parallelise some startup operations

### DIFF
--- a/core-android-api/src/main/java/com/jraska/github/client/core/android/OnAppCreate.kt
+++ b/core-android-api/src/main/java/com/jraska/github/client/core/android/OnAppCreate.kt
@@ -5,3 +5,12 @@ import android.app.Application
 interface OnAppCreate {
   fun onCreate(app: Application)
 }
+
+/**
+ * Interface to parallelise startup of time consuming components.
+ *
+ * Initialisations which are not necessarily critical and don't have to block should happen here.
+ */
+interface OnAppCreateAsync {
+  fun onCreateAsync(app: Application)
+}

--- a/core/src/main/java/com/jraska/github/client/core/android/CoreAndroidModule.kt
+++ b/core/src/main/java/com/jraska/github/client/core/android/CoreAndroidModule.kt
@@ -26,6 +26,7 @@ import dagger.multibindings.IntoMap
 import dagger.multibindings.IntoSet
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
 import io.reactivex.rxjava3.schedulers.Schedulers
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module
@@ -105,11 +106,11 @@ object CoreAndroidModule {
 
   @Provides
   @IntoSet
-  fun reportAppCreateEvent(eventAnalytics: EventAnalytics): OnAppCreate {
-    return object : OnAppCreate {
-      override fun onCreate(app: Application) {
+  fun reportAppCreateEvent(eventAnalytics: Provider<EventAnalytics>): OnAppCreateAsync {
+    return object : OnAppCreateAsync {
+      override fun onCreateAsync(app: Application) {
         val createEvent = AnalyticsEvent.create(AnalyticsEvent.Key("app_create", Owner.CORE_TEAM))
-        eventAnalytics.report(createEvent)
+        eventAnalytics.get().report(createEvent)
       }
     }
   }
@@ -119,17 +120,21 @@ object CoreAndroidModule {
 
   @Provides
   @IntoSet
-  fun setupFresco(): OnAppCreate {
-    return object : OnAppCreate {
-      override fun onCreate(app: Application) = Fresco.initialize(app)
-    }
-  }
-
-  @Provides
-  @IntoSet
   fun setupThreeTen(): OnAppCreate {
     return object : OnAppCreate {
       override fun onCreate(app: Application) = AndroidThreeTen.init(app)
     }
   }
+
+  @Provides
+  @IntoSet
+  fun setupFresco(): OnAppCreateAsync {
+    return object : OnAppCreateAsync {
+      override fun onCreateAsync(app: Application) = Fresco.initialize(app)
+    }
+  }
+
+  @Provides
+  @IntoSet
+  fun bindAppAsync(executor: OnAppCreateAsyncExecutor): OnAppCreate = executor
 }

--- a/core/src/main/java/com/jraska/github/client/core/android/OnAppCreateAsyncExecutor.kt
+++ b/core/src/main/java/com/jraska/github/client/core/android/OnAppCreateAsyncExecutor.kt
@@ -1,0 +1,27 @@
+package com.jraska.github.client.core.android
+
+import android.app.Application
+import com.jraska.github.client.rx.AppSchedulers
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.internal.functions.Functions
+import javax.inject.Inject
+
+class OnAppCreateAsyncExecutor @Inject constructor(
+  private val asyncActions: @JvmSuppressWildcards Set<OnAppCreateAsync>,
+  private val appSchedulers: AppSchedulers
+) : OnAppCreate {
+  override fun onCreate(app: Application) {
+    asyncActions.forEach { appCreateAsync ->
+      Completable.fromAction { appCreateAsync.onCreateAsync(app) }
+        .subscribeOn(appSchedulers.computation)
+        .subscribe(Functions.EMPTY_ACTION, { crashTheApp(it) })
+    }
+  }
+
+  // From https://github.com/ReactiveX/RxJava/blob/0df952e007814da9f2d4566097676590b977c708/src/main/java/io/reactivex/rxjava3/plugins/RxJavaPlugins.java#L431
+  private fun crashTheApp(error: Throwable) {
+    val currentThread = Thread.currentThread()
+    val handler = currentThread.uncaughtExceptionHandler!!
+    handler.uncaughtException(currentThread, error)
+  }
+}

--- a/feature/in-app-update/src/main/java/com/jraska/github/client/inappupdate/InAppUpdateModule.kt
+++ b/feature/in-app-update/src/main/java/com/jraska/github/client/inappupdate/InAppUpdateModule.kt
@@ -5,19 +5,20 @@ import android.content.Context
 import com.jraska.github.client.config.MutableConfigDef
 import com.jraska.github.client.config.MutableConfigSetup
 import com.jraska.github.client.config.MutableConfigType
-import com.jraska.github.client.core.android.OnAppCreate
+import com.jraska.github.client.core.android.OnAppCreateAsync
 import dagger.Module
 import dagger.Provides
 import dagger.multibindings.IntoSet
+import javax.inject.Provider
 
 @Module
 object InAppUpdateModule {
   @Provides
   @IntoSet
-  internal fun checkOnAppCreate(checkScheduler: UpdateCheckScheduler): OnAppCreate {
-    return object : OnAppCreate {
-      override fun onCreate(app: Application) {
-        checkScheduler.startNonBlockingCheck()
+  internal fun checkOnAppCreate(checkScheduler: Provider<UpdateCheckScheduler>): OnAppCreateAsync {
+    return object : OnAppCreateAsync {
+      override fun onCreateAsync(app: Application) {
+        checkScheduler.get().startNonBlockingCheck()
       }
     }
   }

--- a/feature/users/src/main/java/com/jraska/github/client/users/UsersModule.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/UsersModule.kt
@@ -1,11 +1,13 @@
 package com.jraska.github.client.users
 
 import android.app.Activity
+import android.app.Application
 import androidx.lifecycle.ViewModel
 import com.jraska.github.client.config.MutableConfigDef
 import com.jraska.github.client.config.MutableConfigSetup
 import com.jraska.github.client.config.MutableConfigType
 import com.jraska.github.client.core.android.LinkLauncher
+import com.jraska.github.client.core.android.OnAppCreateAsync
 import com.jraska.github.client.rx.AppSchedulers
 import com.jraska.github.client.users.model.GitHubApiUsersRepository
 import com.jraska.github.client.users.model.GitHubUsersApi
@@ -18,6 +20,7 @@ import dagger.multibindings.IntoMap
 import dagger.multibindings.IntoSet
 import okhttp3.HttpUrl
 import retrofit2.Retrofit
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module
@@ -66,6 +69,20 @@ object UsersModule {
 
       override fun priority(): LinkLauncher.Priority {
         return LinkLauncher.Priority.EXACT_MATCH
+      }
+    }
+  }
+
+  /**
+   * This is an optimisation of the app startup - all features SHOULD NOT do this as it consumes app startup resources.
+   * This is recommended only for features loaded at the app startup.
+   */
+  @Provides
+  @IntoSet
+  internal fun prepareHttpClient(usersRepositoryProvider: Provider<UsersRepository>): OnAppCreateAsync {
+    return object : OnAppCreateAsync {
+      override fun onCreateAsync(app: Application) {
+        usersRepositoryProvider.get() // setups asynchronously the rest client
       }
     }
   }


### PR DESCRIPTION
### Context
- Did some profiling of the app startup and identified few bottlenecks
- The big part is system setting activity so this is hard to optimise
- One issue not addressed was logging being costly - this is now considered ok.
- Funnily enough Firebase Performance is using Protobuf Lite, which sucks and has impact on UI performance 🤦 
- _Screenshots below..._

### Changes
- `OnAppCreateAsyncExecutor : OnAppCreate` was added, spinning some threads to offload startup work.
- One of the biggest contributors was Retrofit services setup - this is now done async on startup whilst the system builds the UI
- Remote config was beeing checked as part of some dependencies, this is async as well now
- Fresco init takes a long time - this got offloaded into async thread as well, though this brings a potential for crash if the async init does not run before onResume- since there is still a long gap this is considered as low risk - if Crashlytics would tell us otherwise, there is still room to manoeuvre with priority of the `OnAppCreateAsyncExecutor` as `OnCreateAction`. 

<img width="1354" alt="Screenshot 2021-06-06 at 19 12 06" src="https://user-images.githubusercontent.com/6277721/120933647-516b2780-c6fb-11eb-8a68-157acd75a185.png">
<img width="491" alt="Screenshot 2021-06-06 at 19 12 13" src="https://user-images.githubusercontent.com/6277721/120933649-5334eb00-c6fb-11eb-8500-de50a2170c09.png">
<img width="627" alt="Screenshot 2021-06-06 at 19 12 52" src="https://user-images.githubusercontent.com/6277721/120933650-53cd8180-c6fb-11eb-9599-1bb274967ed9.png">