### PR TITLE
Run firebase separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,22 @@ jobs:
         run: ./gradlew androidDependencies --stacktrace
       - name: Run Tests
         run: ./gradlew check --stacktrace
+  ui-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+      - name: Cache Dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/transforms-2
+          key: build-${{ hashFiles('build.gradle') }}-${{ hashFiles('dependencies.gradle') }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}-${{ hashFiles('app/build.gradle') }}
+      - name: Get Dependencies
+        if: steps.cache-dependencies.outputs.cache-hit != 'true'
+        run: ./gradlew androidDependencies --stacktrace
       - name: Run Tests Firebase
         env:
           GCLOUD_CREDENTIALS: ${{ secrets.GCLOUD_CREDENTIALS }}

--- a/core-api/src/main/java/com/jraska/github/client/rx/AppSchedulers.kt
+++ b/core-api/src/main/java/com/jraska/github/client/rx/AppSchedulers.kt
@@ -6,4 +6,8 @@ class AppSchedulers(
   val mainThread: Scheduler,
   val io: Scheduler,
   val computation: Scheduler
-)
+) {
+  fun changePublicApi() {
+
+  }
+}


### PR DESCRIPTION
- With the remote cache this makes way more sense 
- Tasks from parallel jobs support each other