### PR TITLE
Fix Firebase Test Lab XML parsing

### DIFF
--- a/plugins/src/main/java/com/jraska/github/client/firebase/report/FirebaseResultExtractor.kt
+++ b/plugins/src/main/java/com/jraska/github/client/firebase/report/FirebaseResultExtractor.kt
@@ -17,7 +17,7 @@ class FirebaseResultExtractor(
   private val device: Device
 ) {
   fun extract(xml: String): TestSuiteResult {
-    val testSuiteNode = XmlParser().parseText(xml)
+    val testSuiteNode = (XmlParser().parseText(xml).get("testsuite") as NodeList).first() as Node
 
     val testsCount = testSuiteNode.attributeInt("tests")
     val flakyTests = testSuiteNode.attributeInt("flakes")

--- a/plugins/src/test/kotlin/com/jraska/github/client/firebase/report/FirebaseResultExtractorTest.kt
+++ b/plugins/src/test/kotlin/com/jraska/github/client/firebase/report/FirebaseResultExtractorTest.kt
@@ -76,6 +76,7 @@ class FirebaseResultExtractorTest {
   companion object {
     val SUCCESS_RESULT =
       """
+        <testsuites>
         <testsuite name="" tests="14" failures="0" errors="0" skipped="0" time="15.511" timestamp="2020-11-14T19:39:23" hostname="localhost">
         <properties/>
         <testcase name="appCreateEventFired" classname="com.jraska.github.client.AppSetupTest" time="0.026"/>
@@ -93,9 +94,11 @@ class FirebaseResultExtractorTest {
         <testcase name="testPushIntegration_fromSettingsToAbout" classname="com.jraska.github.client.xpush.PushIntegrationTest" time="4.497"/>
         <testcase name="testPushIntegration_fromAboutToSettings" classname="com.jraska.github.client.xpush.PushIntegrationTest" time="0.628"/>
         </testsuite>
+        </testsuites>
       """.trimIndent()
 
     val ERROR_RESULT = """
+      <testsuites>
       <testsuite name="" tests="14" failures="1" errors="0" skipped="0" time="13.846" timestamp="2020-11-14T00:30:59" hostname="localhost">
       <properties/>
       <testcase name="appCreateEventFired" classname="com.jraska.github.client.AppSetupTest" time="0.0"/>
@@ -115,6 +118,7 @@ class FirebaseResultExtractorTest {
       <testcase name="testPushIntegration_fromSettingsToAbout" classname="com.jraska.github.client.xpush.PushIntegrationTest" time="3.308"/>
       <testcase name="testPushIntegration_fromAboutToSettings" classname="com.jraska.github.client.xpush.PushIntegrationTest" time="1.104"/>
       </testsuite>
+      </testsuites>
     """.trimIndent()
   }
 }


### PR DESCRIPTION
- Changed format with added new root node `<testsuites>`

### Before
```
        <testsuite name="" tests="14" failures="0" ...
```

### After
```
<testsuites>
        <testsuite name="" tests="14" failures="0" ...
```