### PR TITLE
Update again Firebase XML parsing

### DIFF
--- a/plugins/src/main/java/com/jraska/github/client/firebase/report/FirebaseResultExtractor.kt
+++ b/plugins/src/main/java/com/jraska/github/client/firebase/report/FirebaseResultExtractor.kt
@@ -17,7 +17,12 @@ class FirebaseResultExtractor(
   private val device: Device
 ) {
   fun extract(xml: String): TestSuiteResult {
-    val testSuiteNode = (XmlParser().parseText(xml).get("testsuite") as NodeList).first() as Node
+    val rootNode = XmlParser().parseText(xml)
+    val testSuiteNode = if(rootNode.name() == "testsuite") {
+      rootNode
+    } else {
+      (rootNode.get("testsuite") as NodeList).first() as Node
+    }
 
     val testsCount = testSuiteNode.attributeInt("tests")
     val flakyTests = testSuiteNode.attributeInt("flakes")

--- a/plugins/src/test/kotlin/com/jraska/github/client/firebase/report/FirebaseResultExtractorTest.kt
+++ b/plugins/src/test/kotlin/com/jraska/github/client/firebase/report/FirebaseResultExtractorTest.kt
@@ -76,7 +76,6 @@ class FirebaseResultExtractorTest {
   companion object {
     val SUCCESS_RESULT =
       """
-        <testsuites>
         <testsuite name="" tests="14" failures="0" errors="0" skipped="0" time="15.511" timestamp="2020-11-14T19:39:23" hostname="localhost">
         <properties/>
         <testcase name="appCreateEventFired" classname="com.jraska.github.client.AppSetupTest" time="0.026"/>
@@ -94,7 +93,6 @@ class FirebaseResultExtractorTest {
         <testcase name="testPushIntegration_fromSettingsToAbout" classname="com.jraska.github.client.xpush.PushIntegrationTest" time="4.497"/>
         <testcase name="testPushIntegration_fromAboutToSettings" classname="com.jraska.github.client.xpush.PushIntegrationTest" time="0.628"/>
         </testsuite>
-        </testsuites>
       """.trimIndent()
 
     val ERROR_RESULT = """


### PR DESCRIPTION
- Firebase changed format back after https://github.com/jraska/github-client/pull/591 - removed new root node `<testsuites>`
- Now supporting both formats

### Before
```
<testsuites>
        <testsuite name="" tests="14" failures="0" ...
```

### After
```
        <testsuite name="" tests="14" failures="0" ...
```

