### PR TITLE
Dependencies shaking to reduce duplicate artifacts

### DIFF
--- a/app-partial-users/build.gradle
+++ b/app-partial-users/build.gradle
@@ -40,11 +40,15 @@ dependencies {
   implementation project(':feature:users')
 
   implementation 'androidx.appcompat:appcompat:1.3.1'
-  implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-  implementation 'com.google.android.material:material:1.4.0'
   implementation 'androidx.cardview:cardview:1.0.0'
-
+  implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+  implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.1"
   implementation 'androidx.lifecycle:lifecycle-runtime:2.3.1'
+  implementation 'androidx.media:media:1.4.1'
+  implementation 'androidx.recyclerview:recyclerview:1.2.1'
+  implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+  implementation 'com.google.android.material:material:1.4.0'
+
 
   implementation retrofit
   implementation 'com.jakewharton.timber:timber:5.0.1'
@@ -56,7 +60,10 @@ dependencies {
   kapt daggerAnnotationProcessor
   implementation dagger
 
+  implementation coroutinesCore
+
   implementation 'com.jakewharton.threetenabp:threetenabp:1.3.1'
   implementation okHttpLoggingInterceptor
+  implementation 'com.squareup.okio:okio:2.10.0'
 
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -113,12 +113,19 @@ dependencies {
   implementation project(':feature:config-debug-api')
 
   implementation 'androidx.appcompat:appcompat:1.3.1'
-  implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-  implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.browser:browser:1.3.0'
   implementation 'androidx.cardview:cardview:1.0.0'
   implementation 'androidx.core:core:1.6.0'
-  implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
+  implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+  implementation 'androidx.lifecycle:lifecycle-runtime:2.3.1'
   implementation 'androidx.media:media:1.4.1'
+  implementation 'androidx.recyclerview:recyclerview:1.2.1'
+  implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
+  implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
+
+  implementation 'com.airbnb.android:epoxy:4.6.2'
+
+  implementation 'com.google.android.material:material:1.4.0'
 
   implementation platform('com.google.firebase:firebase-bom:28.4.0')
   implementation 'com.google.firebase:firebase-core'
@@ -129,11 +136,7 @@ dependencies {
   implementation 'com.google.firebase:firebase-inappmessaging-display'
   implementation 'com.google.firebase:firebase-database'
 
-  implementation 'androidx.lifecycle:lifecycle-runtime:2.3.1'
-
   implementation fresco
-
-  implementation 'com.airbnb.android:epoxy:4.6.2'
 
   kapt daggerAnnotationProcessor
   implementation dagger

--- a/core-android-api/build.gradle
+++ b/core-android-api/build.gradle
@@ -18,9 +18,10 @@ android {
 }
 
 dependencies {
-  implementation 'androidx.appcompat:appcompat:1.3.1'
   implementation 'androidx.annotation:annotation:1.2.0'
-  implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+  implementation 'androidx.core:core:1.6.0'
+  implementation 'androidx.lifecycle:lifecycle-viewmodel:2.3.1'
+  implementation 'androidx.fragment:fragment:1.3.6'
 
   implementation okHttp
   implementation 'com.squareup.okio:okio:2.10.0'

--- a/core-android-api/src/main/java/com/jraska/github/client/core/android/BaseActivity.kt
+++ b/core-android-api/src/main/java/com/jraska/github/client/core/android/BaseActivity.kt
@@ -1,5 +1,0 @@
-package com.jraska.github.client.core.android
-
-import androidx.appcompat.app.AppCompatActivity
-
-abstract class BaseActivity : AppCompatActivity()

--- a/core-android-testing/build.gradle
+++ b/core-android-testing/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation dagger
 
   implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+  implementation 'androidx.core:core:1.6.0'
   implementation coroutinesJvm
 
   implementation espressoIdlingResource
@@ -33,4 +34,6 @@ dependencies {
   implementation okHttpMockWebServer
   implementation okHttp
   implementation 'com.squareup.okio:okio:2.10.0'
+
+  implementation 'junit:junit:4.13.2'
 }

--- a/core-testing/build.gradle
+++ b/core-testing/build.gradle
@@ -29,4 +29,5 @@ dependencies {
   implementation okHttp
   implementation okHttpMockWebServer
   implementation okHttpLoggingInterceptor
+  implementation 'com.squareup.okio:okio:2.10.0'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   implementation project(':core-android-api')
 
   implementation 'androidx.appcompat:appcompat:1.3.1'
+  implementation 'androidx.core:core:1.6.0'
   implementation 'androidx.annotation:annotation:1.2.0'
   implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
   implementation 'org.threeten:threetenbp:1.5.1:no-tzdb'
@@ -41,6 +42,8 @@ dependencies {
 
   implementation 'com.jakewharton.timber:timber:5.0.1'
   implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.appcompat:appcompat:1.3.1'
+  implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
   implementation retrofit
   implementation retrofitGsonConverter

--- a/core/src/main/java/com/jraska/github/client/core/android/UriHandlerActivity.kt
+++ b/core/src/main/java/com/jraska/github/client/core/android/UriHandlerActivity.kt
@@ -1,8 +1,9 @@
 package com.jraska.github.client.core.android
 
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 
-class UriHandlerActivity : BaseActivity() {
+class UriHandlerActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,6 @@
 ext {
   coroutinesVersion = "1.5.2"
+  coroutinesCore = "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
   coroutinesJvm = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$coroutinesVersion"
   coroutinesAndroid = "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
   coroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutinesVersion"

--- a/feature/about/build.gradle
+++ b/feature/about/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation frescoDrawee
   implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.appcompat:appcompat:1.3.1'
 
   androidTestImplementation 'junit:junit:4.13.2'
   androidTestImplementation espressoCore

--- a/feature/about/src/main/java/com/jraska/github/client/about/AboutActivity.kt
+++ b/feature/about/src/main/java/com/jraska/github/client/about/AboutActivity.kt
@@ -3,14 +3,14 @@ package com.jraska.github.client.about
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.SimpleEpoxyAdapter
-import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 
-internal class AboutActivity : BaseActivity() {
+internal class AboutActivity : AppCompatActivity() {
 
   private val viewModel: AboutViewModel by lazy { viewModel(AboutViewModel::class.java) }
 

--- a/feature/chrome-custom-tabs/build.gradle
+++ b/feature/chrome-custom-tabs/build.gradle
@@ -22,6 +22,6 @@ dependencies {
   implementation dagger
   kapt daggerAnnotationProcessor
   implementation 'androidx.browser:browser:1.3.0'
-
+  implementation 'androidx.core:core:1.6.0'
   testImplementation 'junit:junit:4.13.2'
 }

--- a/feature/network-status/build.gradle
+++ b/feature/network-status/build.gradle
@@ -21,9 +21,13 @@ dependencies {
   kapt daggerAnnotationProcessor
   implementation dagger
 
-  implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.appcompat:appcompat:1.3.1'
+  implementation 'androidx.core:core:1.6.0'
   implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
+  implementation 'androidx.recyclerview:recyclerview:1.2.1'
+  implementation 'com.google.android.material:material:1.4.0'
   implementation coroutinesJvm
+  implementation coroutinesAndroid
   implementation 'com.jakewharton.timber:timber:5.0.1'
 
   testImplementation 'junit:junit:4.13.2'

--- a/feature/push/build.gradle
+++ b/feature/push/build.gradle
@@ -19,7 +19,11 @@ dependencies {
   implementation project(':core-android-api')
   implementation project(':feature:identity-api')
 
+  implementation 'androidx.core:core:1.6.0'
+  implementation 'androidx.appcompat:appcompat:1.3.1'
+
   implementation platform('com.google.firebase:firebase-bom:28.4.0')
+  implementation 'com.google.firebase:firebase-perf'
   implementation 'com.google.firebase:firebase-messaging'
   implementation 'com.google.firebase:firebase-database'
 

--- a/feature/repo/build.gradle
+++ b/feature/repo/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   implementation dagger
 
   implementation coroutinesAndroid
+  implementation coroutinesCore
+  implementation coroutinesJvm
   implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.1"
 
   implementation retrofit
@@ -35,6 +37,7 @@ dependencies {
   implementation 'com.google.code.gson:gson:2.8.8'
 
   implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.appcompat:appcompat:1.3.1'
   implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'com.airbnb.android:epoxy:4.6.2'
   implementation fresco

--- a/feature/repo/src/main/java/com/jraska/github/client/repo/ui/RepoDetailActivity.kt
+++ b/feature/repo/src/main/java/com/jraska/github/client/repo/ui/RepoDetailActivity.kt
@@ -3,12 +3,12 @@ package com.jraska.github.client.repo.ui
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.airbnb.epoxy.SimpleEpoxyModel
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 import com.jraska.github.client.repo.R
 import com.jraska.github.client.repo.RepoDetailViewModel
@@ -16,7 +16,7 @@ import com.jraska.github.client.repo.model.RepoDetail
 import com.jraska.github.client.users.ui.ErrorHandler
 import com.jraska.github.client.users.ui.SimpleTextModel
 
-internal class RepoDetailActivity : BaseActivity() {
+internal class RepoDetailActivity : AppCompatActivity() {
 
   private val viewModel: RepoDetailViewModel by lazy { viewModel(RepoDetailViewModel::class.java) }
 

--- a/feature/settings/build.gradle
+++ b/feature/settings/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
   implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.appcompat:appcompat:1.3.1'
   implementation 'com.airbnb.android:epoxy:4.6.2'
   implementation 'com.jraska:console:1.2.0'
   implementation 'com.jraska:console-timber-tree:1.2.0'

--- a/feature/settings/src/main/java/com/jraska/github/client/settings/ConsoleActivity.kt
+++ b/feature/settings/src/main/java/com/jraska/github/client/settings/ConsoleActivity.kt
@@ -3,10 +3,10 @@ package com.jraska.github.client.settings
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import com.jraska.console.Console
-import com.jraska.github.client.core.android.BaseActivity
 
-internal class ConsoleActivity : BaseActivity() {
+internal class ConsoleActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(Console(this))

--- a/feature/settings/src/main/java/com/jraska/github/client/settings/SettingsActivity.kt
+++ b/feature/settings/src/main/java/com/jraska/github/client/settings/SettingsActivity.kt
@@ -3,14 +3,14 @@ package com.jraska.github.client.settings
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyModel
 import com.airbnb.epoxy.SimpleEpoxyAdapter
-import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 
-internal class SettingsActivity : BaseActivity() {
+internal class SettingsActivity : AppCompatActivity() {
   private val viewModel: SettingsViewModel by lazy { viewModel(SettingsViewModel::class.java) }
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/feature/shortcuts/build.gradle
+++ b/feature/shortcuts/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   implementation project(':core-android-api')
 
   implementation 'androidx.appcompat:appcompat:1.3.1'
+  implementation 'androidx.core:core:1.6.0'
 
   kapt daggerAnnotationProcessor
   implementation dagger

--- a/feature/shortcuts/src/main/java/com/jraska/github/client/shortcuts/ShortcutHandlerActivity.kt
+++ b/feature/shortcuts/src/main/java/com/jraska/github/client/shortcuts/ShortcutHandlerActivity.kt
@@ -1,11 +1,11 @@
 package com.jraska.github.client.shortcuts
 
 import android.os.Bundle
-import com.jraska.github.client.core.android.BaseActivity
+import androidx.appcompat.app.AppCompatActivity
 import com.jraska.github.client.core.android.inputUrl
 import com.jraska.github.client.core.android.viewModel
 
-internal class ShortcutHandlerActivity : BaseActivity() {
+internal class ShortcutHandlerActivity : AppCompatActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/feature/ui-common-api/build.gradle
+++ b/feature/ui-common-api/build.gradle
@@ -18,7 +18,8 @@ android {
 }
 
 dependencies {
-  implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.recyclerview:recyclerview:1.2.1'
+  implementation 'androidx.core:core:1.6.0'
   implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'com.airbnb.android:epoxy:4.6.2'
 }

--- a/feature/users/build.gradle
+++ b/feature/users/build.gradle
@@ -40,8 +40,10 @@ dependencies {
   implementation retrofitGsonConverter
   implementation 'com.google.code.gson:gson:2.8.8'
   implementation coroutinesJvm
+  implementation coroutinesCore
 
   implementation 'com.google.android.material:material:1.4.0'
+  implementation 'androidx.appcompat:appcompat:1.3.1'
   implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
   implementation 'androidx.recyclerview:recyclerview:1.2.1'
   implementation 'com.airbnb.android:epoxy:4.6.2'

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/UserDetailActivity.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/UserDetailActivity.kt
@@ -3,6 +3,7 @@ package com.jraska.github.client.users.ui
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.airbnb.epoxy.EpoxyModel
@@ -10,14 +11,13 @@ import com.airbnb.epoxy.SimpleEpoxyAdapter
 import com.airbnb.epoxy.SimpleEpoxyModel
 import com.facebook.drawee.view.SimpleDraweeView
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.UserDetailViewModel
 import com.jraska.github.client.users.model.RepoHeader
 import com.jraska.github.client.users.model.UserDetail
 
-internal class UserDetailActivity : BaseActivity() {
+internal class UserDetailActivity : AppCompatActivity() {
 
   private val userDetailViewModel: UserDetailViewModel by lazy { viewModel(UserDetailViewModel::class.java) }
 

--- a/feature/users/src/main/java/com/jraska/github/client/users/ui/UsersActivity.kt
+++ b/feature/users/src/main/java/com/jraska/github/client/users/ui/UsersActivity.kt
@@ -5,17 +5,17 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.airbnb.epoxy.SimpleEpoxyAdapter
-import com.jraska.github.client.core.android.BaseActivity
 import com.jraska.github.client.core.android.viewModel
 import com.jraska.github.client.users.R
 import com.jraska.github.client.users.UsersViewModel
 import com.jraska.github.client.users.model.User
 
-class UsersActivity : BaseActivity(), UserModel.UserListener {
+class UsersActivity : AppCompatActivity(), UserModel.UserListener {
   private val usersViewModel: UsersViewModel by lazy { viewModel(UsersViewModel::class.java) }
 
   private val usersRecycler: RecyclerView get() = findViewById(R.id.users_recycler)

--- a/navigation-api/build.gradle
+++ b/navigation-api/build.gradle
@@ -5,4 +5,5 @@ apply plugin: 'kotlin'
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation okHttp
+  implementation 'com.squareup.okio:okio:2.10.0'
 }


### PR DESCRIPTION
- Due to trasitive dependencies and different artifacts in different modules, many artifacts end up duplicated with different version
- This cause Android Studio to index them, Gradle to pull them and CI to cache them
- This PR reduced number of artifacts from 223 to 203
- Better solution is probably Platform project - this will be trialed later