### PR TITLE
Synchronize idling dispatcher as the modifications are concurrent

### DIFF
--- a/core-android-testing/src/main/java/com/jraska/github/client/android/test/IdlingDispatcher.kt
+++ b/core-android-testing/src/main/java/com/jraska/github/client/android/test/IdlingDispatcher.kt
@@ -18,8 +18,10 @@ class IdlingDispatcher(
   override fun getName() = "Coroutines IdlingDispatcher"
 
   override fun isIdleNow(): Boolean {
-    jobs.removeAll { !it.isActive }
-    return jobs.isEmpty()
+    synchronized(jobs) {
+      jobs.removeAll { !it.isActive }
+      return jobs.isEmpty()
+    }
   }
 
   override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
@@ -44,7 +46,10 @@ class IdlingDispatcher(
 
   private fun addNewJob(job: Job) {
     job.invokeOnCompletion { onJobComplete() }
-    jobs.add(job)
+
+    synchronized(jobs) {
+      jobs.add(job)
+    }
   }
 
   private fun onJobComplete() {


### PR DESCRIPTION
- Got 2 crashes on TestLab: [1](https://console.firebase.google.com/project/github-client-25b47/testlab/histories/bh.45e06288a93d3fad/matrices/4620759304092688230/executions/bs.54ff17934fe2fcf2), [2](https://console.firebase.google.com/project/github-client-25b47/testlab/histories/bh.45e06288a93d3fad/matrices/4970157685302084440/executions/bs.ed3e778e753346a8)