### PR TITLE
Fix configuredTime when configuration error

### DIFF
--- a/plugins/src/main/java/com/jraska/gradle/buildtime/BuildTimeListener.kt
+++ b/plugins/src/main/java/com/jraska/gradle/buildtime/BuildTimeListener.kt
@@ -14,7 +14,7 @@ internal class BuildTimeListener(
   private val buildReporter: BuildReporter
 ) : BuildListener {
   private val taskExecutionStatisticsEventAdapter = TaskExecutionStatisticsEventAdapter()
-  private var configuredTime: Long = 0
+  private var configuredTime: Long? = null
 
   override fun settingsEvaluated(gradle: Settings) = Unit
   override fun projectsLoaded(gradle: Gradle) = Unit
@@ -26,7 +26,13 @@ internal class BuildTimeListener(
   }
 
   override fun buildFinished(result: BuildResult) {
-    val buildData = buildDataFactory.buildData(result, taskExecutionStatisticsEventAdapter.statistics, configuredTime)
+    if (configuredTime == null) {
+      val gradle = result.gradle as DefaultGradle
+      val services = gradle.services
+
+      configuredTime = services[Clock::class.java].currentTime
+    }
+    val buildData = buildDataFactory.buildData(result, taskExecutionStatisticsEventAdapter.statistics, configuredTime!!)
 
     println("Build data collected in ${buildData.buildDataCollectionOverhead} ms")
 


### PR DESCRIPTION
Hey, hope you're getting lots of glovo discounts 😄

I found this issue at work today so may as well solve it here too. When an error occurs in a gradle build script `projectsEvaluated(gradle: Gradle)` is never executed, meaning configuredTime = 0 and the configuration duration estimate will be 0-startTimeStamp.

To fix this, when the value is null we can assume the configuration phase failed so we use the currentTime instead.

You can test this by adding `throw new Exception()` into a project's `build.gradle` file and printing `configuredTime` both before and after this change by running `./gradlew help`