### PR TITLE
Add pull_request_target on build to be triggered from forked repos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: [push]
+on: [push, pull_request_target]
 env:
   GITHUB_CLIENT_MIXPANEL_API_KEY: ${{ secrets.MIXPANEL_KEY }}
 jobs:


### PR DESCRIPTION
- Build workflows are not triggered on forked PRs - e.g. #691 
- See [GitHub docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull-request-events-for-forked-repositories)