### PR TITLE
Update Firebase URL parser

### DIFF
--- a/plugins/src/main/java/com/jraska/github/client/firebase/report/FirebaseUrlParser.kt
+++ b/plugins/src/main/java/com/jraska/github/client/firebase/report/FirebaseUrlParser.kt
@@ -1,12 +1,12 @@
 package com.jraska.github.client.firebase.report
 
 object FirebaseUrlParser {
-  private val urlPattern = """Test results will be streamed to \[(\S*)\]""".toPattern()
+  private val urlPattern = """Test results will be streamed to \[([\S ]*)\]""".toPattern()
 
   fun parse(output: String): String {
     val matcher = urlPattern.matcher(output)
 
     matcher.find()
-    return matcher.group(1)
+    return matcher.group(1).trim()
   }
 }

--- a/plugins/src/test/kotlin/com/jraska/github/client/firebase/report/FirebaseUrlParserTest.kt
+++ b/plugins/src/test/kotlin/com/jraska/github/client/firebase/report/FirebaseUrlParserTest.kt
@@ -11,6 +11,13 @@ class FirebaseUrlParserTest {
     assertThat(url).isEqualTo("https://console.firebase.google.com/project/github-client-25b47/testlab/histories/bh.45e06288a93d3fad/matrices/4937539158600939569")
   }
 
+  @Test
+  fun findsNewUrlProperly() {
+    val url = FirebaseUrlParser.parse(EXAMPLE_OUTPUT_2)
+
+    assertThat(url).isEqualTo("https://console.firebase.google.com/project/github-client-25b47/testlab/histories/bh.45e06288a93d3fad/matrices/4992084868422917621")
+  }
+
   companion object {
     val EXAMPLE_OUTPUT = """
       Have questions, feedback, or issues? Get support by visiting:
@@ -59,6 +66,40 @@ class FirebaseUrlParserTest {
       ├─────────┼──────────────────────┼────────────────────────────────┤
       │ Failed  │ flame-29-en-portrait │ 1 test cases failed, 13 passed │
       └─────────┴──────────────────────┴────────────────────────────────┘
+    """.trimIndent()
+
+    val EXAMPLE_OUTPUT_2 = """
+      Have questions, feedback, or issues? Get support by visiting:
+        https://firebase.google.com/support/
+
+      Uploading [/home/runner/work/github-client/github-client/app/build/outputs/apk/debug/app-debug.apk] to Firebase Test Lab...
+      Uploading [/home/runner/work/github-client/github-client/app/build/outputs/apk/androidTest/debug/app-debug-androidTest.apk] to Firebase Test Lab...
+      Raw results will be stored in your GCS bucket at [https://console.developers.google.com/storage/browser/test-lab-twsawhz0hy5am-h35y3vymzadax/2022-12-06T19:01:26.459081/]
+
+      Test [matrix-zvqc95opgthaa] has been created in the Google Cloud.
+      Creating individual test executions...
+      ...............................done.
+      Firebase Test Lab will execute your instrumentation test on 2 device(s). More devices may be added later if flaky test attempts are specified.
+
+      Test results will be streamed to [ https://console.firebase.google.com/project/github-client-25b47/testlab/histories/bh.45e06288a93d3fad/matrices/4992084868422917621 ].
+
+      19:02:41 Test matrix status: Pending:2 
+      19:02:53 Test matrix status: Pending:2 
+      19:03:05 Test matrix status: Running:2 
+      19:03:18 Test matrix status: Running:2 
+      19:03:30 Test matrix status: Running:2 
+      19:03:42 Test matrix status: Running:2 
+      19:03:54 Test matrix status: Finished:1 Running:1 
+      19:04:06 Test matrix status: Finished:2           
+      Instrumentation testing complete.
+
+      More details are available at [ https://console.firebase.google.com/project/github-client-25b47/testlab/histories/bh.45e06288a93d3fad/matrices/4992084868422917621 ].
+      ┌─────────┬────────────────────────┬──────────────────────┐
+      │ OUTCOME │    TEST_AXIS_VALUE     │     TEST_DETAILS     │
+      ├─────────┼────────────────────────┼──────────────────────┤
+      │ Passed  │ bluejay-32-en-portrait │ 16 test cases passed │
+      │ Passed  │ cheetah-33-en-portrait │ 16 test cases passed │
+      └─────────┴────────────────────────┴──────────────────────┘
     """.trimIndent()
   }
 }


### PR DESCRIPTION
- Firebase added space the search regex was not accounting for
- Before `[https://url]`, now `[ https://url ]`
- Both formats are now supported.