### PR TITLE
Add session id to network requests

### DIFF
--- a/core/src/main/java/com/jraska/github/client/http/HttpModule.kt
+++ b/core/src/main/java/com/jraska/github/client/http/HttpModule.kt
@@ -6,7 +6,9 @@ import com.jraska.github.client.AppVersion
 import com.jraska.github.client.core.BuildConfig
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
 import okhttp3.Cache
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level
@@ -34,11 +36,11 @@ object HttpModule {
   @Singleton
   internal fun provideOkHttpClient(
     context: Context,
-    appHeadersInterceptor: AppCommonHeadersInterceptor
+    interceptors: @JvmSuppressWildcards Set<Interceptor>
   ): OkHttpClient {
     val builder = OkHttpClient.Builder()
 
-    builder.addInterceptor(appHeadersInterceptor)
+    interceptors.forEach { builder.addInterceptor(it) }
 
     if (BuildConfig.DEBUG) {
       val loggingInterceptor =
@@ -57,7 +59,8 @@ object HttpModule {
 
   @Provides
   @Singleton
-  internal fun appHeadersInterceptor(appVersion: AppVersion): AppCommonHeadersInterceptor {
+  @IntoSet
+  internal fun appHeadersInterceptor(appVersion: AppVersion): Interceptor {
     return AppCommonHeadersInterceptor(appVersion)
   }
 

--- a/feature/identity/build.gradle
+++ b/feature/identity/build.gradle
@@ -9,10 +9,12 @@ dependencies {
   implementation project(':feature:identity-api')
 
   implementation 'org.threeten:threetenbp:1.5.1:no-tzdb'
+  implementation okHttp
 
   kapt daggerAnnotationProcessor
   implementation dagger
 
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'org.assertj:assertj-core:3.23.1'
+  testImplementation okHttpMockWebServer
 }

--- a/feature/identity/src/main/java/com/jraska/github/client/identity/IdentityModule.kt
+++ b/feature/identity/src/main/java/com/jraska/github/client/identity/IdentityModule.kt
@@ -1,10 +1,13 @@
 package com.jraska.github.client.identity
 
+import com.jraska.github.client.identity.internal.AddSessionIdInterceptor
 import com.jraska.github.client.identity.internal.AnonymousIdentity
 import com.jraska.github.client.identity.internal.SessionIdProvider
 import com.jraska.github.client.time.TimeProvider
 import dagger.Module
 import dagger.Provides
+import dagger.multibindings.IntoSet
+import okhttp3.Interceptor
 import javax.inject.Singleton
 
 @Module
@@ -23,5 +26,11 @@ object IdentityModule {
   }
 
   @Provides
-  internal fun identityProvider(implementation: IdentityProviderImpl): IdentityProvider = implementation
+  internal fun identityProvider(impl: IdentityProviderImpl): IdentityProvider = impl
+
+  @Provides
+  @IntoSet
+  internal fun addSessionIdInterceptor(identityProvider: IdentityProvider): Interceptor {
+    return AddSessionIdInterceptor(identityProvider)
+  }
 }

--- a/feature/identity/src/main/java/com/jraska/github/client/identity/internal/AddSessionIdInterceptor.kt
+++ b/feature/identity/src/main/java/com/jraska/github/client/identity/internal/AddSessionIdInterceptor.kt
@@ -1,0 +1,18 @@
+package com.jraska.github.client.identity.internal
+
+import com.jraska.github.client.identity.IdentityProvider
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class AddSessionIdInterceptor(
+  private val identityProvider: IdentityProvider
+) : Interceptor {
+  override fun intercept(chain: Interceptor.Chain): Response {
+    val newRequest = chain.request()
+      .newBuilder()
+      .addHeader("Session-Id", identityProvider.session().id.toString())
+      .build()
+
+    return chain.proceed(newRequest)
+  }
+}


### PR DESCRIPTION
- Added `Session-Id` header from the `:identity` module
- added `@IntoSet` composition for OkHttp interceptors