### PR TITLE
Generic build to build-check-unit-tests to be more explicit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on: [push]
 env:
   GITHUB_CLIENT_MIXPANEL_API_KEY: ${{ secrets.MIXPANEL_KEY }}
 jobs:
-  build:
+  build-check-unit-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code


### PR DESCRIPTION
- `build` was too generic 