### PR TITLE
Remove unused manifests

### DIFF
--- a/core-android-api/src/main/AndroidManifest.xml
+++ b/core-android-api/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/core-android-testing/src/main/AndroidManifest.xml
+++ b/core-android-testing/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/core-testing/src/main/AndroidManifest.xml
+++ b/core-testing/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/feature/chrome-custom-tabs/src/main/AndroidManifest.xml
+++ b/feature/chrome-custom-tabs/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/feature/config-debug/src/main/AndroidManifest.xml
+++ b/feature/config-debug/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/feature/identity-api/src/main/AndroidManifest.xml
+++ b/feature/identity-api/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/feature/identity/src/main/AndroidManifest.xml
+++ b/feature/identity/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/feature/in-app-update/src/main/AndroidManifest.xml
+++ b/feature/in-app-update/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/feature/performance/src/main/AndroidManifest.xml
+++ b/feature/performance/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />

--- a/feature/ui-common-api/src/main/AndroidManifest.xml
+++ b/feature/ui-common-api/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest />


### PR DESCRIPTION
Apparently we don't need the empty files anymore