### PR TITLE
Disable R8 full mode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ kapt.incremental.apt=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
 android.nonTransitiveRClass=true
+android.enableR8.fullMode=false
 
 # https://github.com/gradle/gradle/issues/18935 - can't be bothered now
 kotlin.jvm.target.validation.mode = IGNORE


### PR DESCRIPTION
- Default changed by the Android 8 plugin? https://developer.android.com/build/releases/gradle-plugin
- https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md#r8-full-mode
- Related PR: https://github.com/jraska/github-client/issues/873