### PR TITLE
Enable R8 full mode

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -13,3 +13,6 @@
 # hide the original source file name.
 -renamesourcefileattribute SourceFile
 #-dontobfuscate
+
+# https://github.com/square/retrofit/issues/3005#issuecomment-1523948650
+-keep,allowobfuscation,allowshrinking interface retrofit2.Call

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ kapt.incremental.apt=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
 android.nonTransitiveRClass=true
-android.enableR8.fullMode=false
 
 # https://github.com/gradle/gradle/issues/18935 - can't be bothered now
 kotlin.jvm.target.validation.mode = IGNORE


### PR DESCRIPTION
- Resolves #873 
- Removing the `gradle.properties` configuration to rely on default