### PR TITLE
Switch to underscores

### DIFF
--- a/core/src/main/java/com/jraska/github/client/http/NetworkResourceReporter.kt
+++ b/core/src/main/java/com/jraska/github/client/http/NetworkResourceReporter.kt
@@ -11,13 +11,13 @@ class NetworkResourceReporter @Inject constructor(
 ) {
   fun report(resource: NetworkResource) {
     val analyticsEvent = AnalyticsEvent.builder(NETWORK_RESOURCE_EVENT)
-      .addProperty("http.method", resource.method)
-      .addProperty("http.status_code", resource.statusCode)
-      .addProperty("http.request_content_length", resource.requestContentLength)
-      .addProperty("http.response_content_length", resource.responseContentLength)
-      .addProperty("http.url", resource.url.toAnalyticsString())
-      .addProperty("resource.duration", resource.durationMs)
-      .addProperty("http.request_id", resource.requestId)
+      .addProperty("http_method", resource.method)
+      .addProperty("http_status_code", resource.statusCode)
+      .addProperty("http_request_length", resource.requestContentLength)
+      .addProperty("http_response_length", resource.responseContentLength)
+      .addProperty("http_url", resource.url.toAnalyticsString())
+      .addProperty("resource_duration", resource.durationMs)
+      .addProperty("http_request_id", resource.requestId)
       .build()
 
     eventAnalytics.report(analyticsEvent)

--- a/core/src/test/java/com/jraska/github/client/http/HttpTrackingInterceptorTest.kt
+++ b/core/src/test/java/com/jraska/github/client/http/HttpTrackingInterceptorTest.kt
@@ -44,13 +44,13 @@ class HttpTrackingInterceptorTest {
 
     val analyticsEvent = recordingAnalytics.events().single()
     assertThat(analyticsEvent.key.name).isEqualTo("http_request")
-    assertThat(analyticsEvent.properties["resource.duration"]).isEqualTo(123L)
-    assertThat(analyticsEvent.properties["http.method"]).isEqualTo("GET")
-    assertThat(analyticsEvent.properties["http.request_content_length"]).isEqualTo(0L)
-    assertThat(analyticsEvent.properties["http.response_content_length"]).isEqualTo(0L)
-    assertThat(analyticsEvent.properties["http.status_code"]).isEqualTo(201)
-    assertThat(analyticsEvent.properties["http.request_id"]).isEqualTo("testId")
-    assertThat(analyticsEvent.properties["http.url"] as String)
+    assertThat(analyticsEvent.properties["resource_duration"]).isEqualTo(123L)
+    assertThat(analyticsEvent.properties["http_method"]).isEqualTo("GET")
+    assertThat(analyticsEvent.properties["http_request_length"]).isEqualTo(0L)
+    assertThat(analyticsEvent.properties["http_response_length"]).isEqualTo(0L)
+    assertThat(analyticsEvent.properties["http_status_code"]).isEqualTo(201)
+    assertThat(analyticsEvent.properties["http_request_id"]).isEqualTo("testId")
+    assertThat(analyticsEvent.properties["http_url"] as String)
       .doesNotContain("sensitive").doesNotContain("info").contains("http://localhost:")
   }
 
@@ -70,10 +70,10 @@ class HttpTrackingInterceptorTest {
       .execute()
 
     val analyticsEvent = recordingAnalytics.events().single()
-    assertThat(analyticsEvent.properties["http.method"]).isEqualTo("POST")
-    assertThat(analyticsEvent.properties["http.status_code"]).isEqualTo(200)
-    assertThat(analyticsEvent.properties["http.request_content_length"]).isEqualTo(5L)
-    assertThat(analyticsEvent.properties["http.response_content_length"]).isEqualTo(231L)
+    assertThat(analyticsEvent.properties["http_method"]).isEqualTo("POST")
+    assertThat(analyticsEvent.properties["http_status_code"]).isEqualTo(200)
+    assertThat(analyticsEvent.properties["http_request_length"]).isEqualTo(5L)
+    assertThat(analyticsEvent.properties["http_response_length"]).isEqualTo(231L)
 
     mockWebServer.enqueue(
       MockResponse()
@@ -89,10 +89,10 @@ class HttpTrackingInterceptorTest {
     ).execute()
 
     val secondEvent = recordingAnalytics.events().last()
-    assertThat(secondEvent.properties["http.method"]).isEqualTo("PUT")
-    assertThat(secondEvent.properties["http.status_code"]).isEqualTo(200)
-    assertThat(secondEvent.properties["http.request_content_length"]).isEqualTo(10L)
-    assertThat(secondEvent.properties["http.response_content_length"]).isEqualTo(9L)
+    assertThat(secondEvent.properties["http_method"]).isEqualTo("PUT")
+    assertThat(secondEvent.properties["http_status_code"]).isEqualTo(200)
+    assertThat(secondEvent.properties["http_request_length"]).isEqualTo(10L)
+    assertThat(secondEvent.properties["http_response_length"]).isEqualTo(9L)
   }
 
   private fun builder(): Request.Builder {


### PR DESCRIPTION
- Firebase reports errors with dots in the parameters names