### PR TITLE
Add method info to parsing errors

### DIFF
--- a/core/src/main/java/com/jraska/github/client/http/ErrorLoggingConverterFactory.kt
+++ b/core/src/main/java/com/jraska/github/client/http/ErrorLoggingConverterFactory.kt
@@ -4,11 +4,20 @@ import okhttp3.RequestBody
 import okhttp3.ResponseBody
 import retrofit2.Converter
 import retrofit2.Retrofit
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.HEAD
+import retrofit2.http.HTTP
+import retrofit2.http.OPTIONS
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.PUT
+import java.lang.IllegalArgumentException
 import java.lang.reflect.Type
 
 interface ConvertErrorHandler {
-  fun onConvertRequestBodyError(value: Any, exception: Exception, type: Type)
-  fun onConvertResponseError(exception: Exception, type: Type)
+  fun onConvertRequestBodyError(value: Any, exception: Exception, methodInfo: MethodInfo)
+  fun onConvertResponseError(exception: Exception, methodInfo: MethodInfo)
 }
 
 class ErrorLoggingConverterFactory(
@@ -23,7 +32,8 @@ class ErrorLoggingConverterFactory(
     val delegateConverter = delegate.responseBodyConverter(type, annotations, retrofit)
 
     if (delegateConverter != null) {
-      return ResponseBodyErrorConverter(delegateConverter, jsonErrorHandler, type)
+      val methodInfo = methodInfo(annotations, type)
+      return ResponseBodyErrorConverter(delegateConverter, jsonErrorHandler, methodInfo)
     } else {
       return null
     }
@@ -39,7 +49,8 @@ class ErrorLoggingConverterFactory(
       delegate.requestBodyConverter(type, parameterAnnotations, methodAnnotations, retrofit)
 
     if (delegateConverter != null) {
-      return RequestBodyErrorConverter(delegateConverter, jsonErrorHandler, type)
+      val methodInfo = methodInfo(methodAnnotations, type)
+      return RequestBodyErrorConverter(delegateConverter, jsonErrorHandler, methodInfo)
     } else {
       return null
     }
@@ -53,16 +64,41 @@ class ErrorLoggingConverterFactory(
     return delegate.stringConverter(type, annotations, retrofit)
   }
 
+  private fun methodInfo(annotations: Array<out Annotation>, type: Type): MethodInfo {
+    annotations.forEach {
+      val urlPathWithMethod = urlPathWithMethod(it)
+      if(urlPathWithMethod != null) {
+        return MethodInfo(urlPathWithMethod.first, urlPathWithMethod.second, type)
+      }
+    }
+
+    throw IllegalArgumentException("HTTP Method not found in annotations $annotations for $type")
+  }
+
+  private fun urlPathWithMethod(annotation: Annotation): Pair<String, String>? {
+    return when (annotation) {
+      is DELETE -> annotation.value to "DELETE"
+      is GET -> annotation.value to "GET"
+      is HEAD -> annotation.value to "HEAD"
+      is PATCH -> annotation.value to "PATCH"
+      is POST -> annotation.value to "POST"
+      is PUT -> annotation.value to "PUT"
+      is OPTIONS -> annotation.value to "OPTIONS"
+      is HTTP -> annotation.path to annotation.method
+      else -> null
+    }
+  }
+
   private class ResponseBodyErrorConverter<T>(
     private val delegate: Converter<ResponseBody, T>,
     private val jsonErrorHandler: ConvertErrorHandler,
-    private val type: Type
+    private val methodInfo: MethodInfo
   ) : Converter<ResponseBody, T> {
     override fun convert(value: ResponseBody): T? {
       try {
         return delegate.convert(value)
       } catch (exception: Exception) {
-        jsonErrorHandler.onConvertResponseError(exception, type)
+        jsonErrorHandler.onConvertResponseError(exception, methodInfo)
 
         throw exception
       }
@@ -72,13 +108,13 @@ class ErrorLoggingConverterFactory(
   private class RequestBodyErrorConverter<T>(
     private val delegate: Converter<T, RequestBody>,
     private val jsonErrorHandler: ConvertErrorHandler,
-    private val type: Type
+    private val methodInfo: MethodInfo
   ) : Converter<T, RequestBody> {
     override fun convert(value: T): RequestBody? {
       try {
         return delegate.convert(value)
       } catch (exception: Exception) {
-        jsonErrorHandler.onConvertRequestBodyError(value as Any, exception, type)
+        jsonErrorHandler.onConvertRequestBodyError(value as Any, exception, methodInfo)
 
         throw exception
       }

--- a/core/src/main/java/com/jraska/github/client/http/MethodInfo.kt
+++ b/core/src/main/java/com/jraska/github/client/http/MethodInfo.kt
@@ -1,0 +1,9 @@
+package com.jraska.github.client.http
+
+import java.lang.reflect.Type
+
+class MethodInfo(
+  val httpPath: String,
+  val method: String,
+  val dtoType: Type
+)

--- a/core/src/main/java/com/jraska/github/client/http/ReportingConvertErrorHandler.kt
+++ b/core/src/main/java/com/jraska/github/client/http/ReportingConvertErrorHandler.kt
@@ -1,6 +1,5 @@
 package com.jraska.github.client.http
 
-import android.os.Build.VERSION_CODES.P
 import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics

--- a/core/src/main/java/com/jraska/github/client/http/ReportingConvertErrorHandler.kt
+++ b/core/src/main/java/com/jraska/github/client/http/ReportingConvertErrorHandler.kt
@@ -1,27 +1,27 @@
 package com.jraska.github.client.http
 
+import android.os.Build.VERSION_CODES.P
 import com.jraska.github.client.Owner
 import com.jraska.github.client.analytics.AnalyticsEvent
 import com.jraska.github.client.analytics.EventAnalytics
-import java.lang.reflect.Type
 import javax.inject.Inject
 
 class ReportingConvertErrorHandler @Inject constructor(
   private val eventAnalytics: EventAnalytics
 ) : ConvertErrorHandler {
 
-  override fun onConvertRequestBodyError(value: Any, exception: Exception, type: Type) {
+  override fun onConvertRequestBodyError(value: Any, exception: Exception, methodInfo: MethodInfo) {
     val requestBodyError = AnalyticsEvent.builder(REQUEST_CONVERT_ERROR)
-      .addExceptionProperties(exception, type)
+      .addExceptionProperties(exception, methodInfo)
       .addProperty("value_type", value::class.qualifiedName.max100End())
       .build()
 
     eventAnalytics.report(requestBodyError)
   }
 
-  override fun onConvertResponseError(exception: Exception, type: Type) {
+  override fun onConvertResponseError(exception: Exception, methodInfo: MethodInfo) {
     val responseBodyError = AnalyticsEvent.builder(RESPONSE_CONVERT_ERROR)
-      .addExceptionProperties(exception, type)
+      .addExceptionProperties(exception, methodInfo)
       .build()
 
     eventAnalytics.report(responseBodyError)
@@ -29,15 +29,17 @@ class ReportingConvertErrorHandler @Inject constructor(
 
   private fun AnalyticsEvent.Builder.addExceptionProperties(
     exception: Exception,
-    type: Type
+    methodInfo: MethodInfo,
   ): AnalyticsEvent.Builder {
-    val dtoType = if(type is Class<*>) {
-      type.name
+    val dtoType = if(methodInfo.dtoType is Class<*>) {
+      methodInfo.dtoType.name
     } else {
-      type.toString()
+      methodInfo.dtoType.toString()
     }
 
     addProperty("dto_type", dtoType.max100End())
+    addProperty("http_method", methodInfo.method)
+    addProperty("http_path", methodInfo.httpPath.omitQueryParams().max100End())
     addProperty("message", exception.message.max100End())
     addProperty("error_type", exception::class.simpleName.max100End())
 
@@ -56,6 +58,16 @@ class ReportingConvertErrorHandler @Inject constructor(
     if (length <= 100) return this
 
     return substring(length - 100)
+  }
+
+  private fun String.omitQueryParams(): String {
+    val questionIndex: Int = indexOf('?')
+
+    if(questionIndex > 0) {
+      return substring(0, questionIndex)
+    } else {
+      return this
+    }
   }
 
   companion object {

--- a/core/src/test/java/com/jraska/github/client/http/ErrorLoggingConverterFactoryTest.kt
+++ b/core/src/test/java/com/jraska/github/client/http/ErrorLoggingConverterFactoryTest.kt
@@ -32,6 +32,8 @@ class ErrorLoggingConverterFactoryTest {
 
     val event = eventAnalytics.events().single()
     assertThat(event.name).isEqualTo("error_parsing")
+    assertThat(event.properties["http_method"]).isEqualTo("GET")
+    assertThat(event.properties["http_path"]).isEqualTo("get/some/long/path")
     assertThat(event.properties["error_type"]).isEqualTo("MalformedJsonException")
     assertThat(event.properties["top_frame_method"]).isEqualTo("syntaxError")
     assertThat(event.properties["message"]).isEqualTo("Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path \$.")
@@ -68,6 +70,8 @@ class ErrorLoggingConverterFactoryTest {
 
     val event = eventAnalytics.events().single()
     assertThat(event.name).isEqualTo("error_serializing")
+    assertThat(event.properties["http_method"]).isEqualTo("POST")
+    assertThat(event.properties["http_path"]).isEqualTo("errorPost/path")
     assertThat(event.properties["dto_type"])
       .isEqualTo("com.jraska.github.client.http.ErrorLoggingConverterFactoryTest\$ErrorBodyDto")
     assertThat(event.properties["message"] as String).endsWith("Forgot to register a type adapter?")
@@ -99,10 +103,10 @@ class ErrorLoggingConverterFactoryTest {
     .create(TestApi::class.java)
 
   interface TestApi {
-    @GET("get")
+    @GET("get/some/long/path?queryParam=3")
     fun get(): Call<ResponseDto>
 
-    @POST("errorPost")
+    @POST("errorPost/path")
     fun post(@Body body: ErrorBodyDto): Call<ResponseBody>
   }
 


### PR DESCRIPTION
- Example how to extract Retrofit information
- If we would have Observability, we would need to edit the paths in our Observability Collector