### PR TITLE
Remove unnecessary ConvertErrorHandler interface

### DIFF
--- a/core/src/main/java/com/jraska/github/client/http/ErrorLoggingConverterFactory.kt
+++ b/core/src/main/java/com/jraska/github/client/http/ErrorLoggingConverterFactory.kt
@@ -15,14 +15,9 @@ import retrofit2.http.PUT
 import java.lang.IllegalArgumentException
 import java.lang.reflect.Type
 
-interface ConvertErrorHandler {
-  fun onConvertRequestBodyError(value: Any, exception: Exception, methodInfo: MethodInfo)
-  fun onConvertResponseError(exception: Exception, methodInfo: MethodInfo)
-}
-
 class ErrorLoggingConverterFactory(
   private val delegate: Converter.Factory,
-  private val jsonErrorHandler: ConvertErrorHandler,
+  private val errorHandler: ReportingConvertErrorHandler,
 ) : Converter.Factory() {
   override fun responseBodyConverter(
     type: Type,
@@ -33,7 +28,7 @@ class ErrorLoggingConverterFactory(
 
     if (delegateConverter != null) {
       val methodInfo = methodInfo(annotations, type)
-      return ResponseBodyErrorConverter(delegateConverter, jsonErrorHandler, methodInfo)
+      return ResponseBodyErrorConverter(delegateConverter, errorHandler, methodInfo)
     } else {
       return null
     }
@@ -50,7 +45,7 @@ class ErrorLoggingConverterFactory(
 
     if (delegateConverter != null) {
       val methodInfo = methodInfo(methodAnnotations, type)
-      return RequestBodyErrorConverter(delegateConverter, jsonErrorHandler, methodInfo)
+      return RequestBodyErrorConverter(delegateConverter, errorHandler, methodInfo)
     } else {
       return null
     }
@@ -91,7 +86,7 @@ class ErrorLoggingConverterFactory(
 
   private class ResponseBodyErrorConverter<T>(
     private val delegate: Converter<ResponseBody, T>,
-    private val jsonErrorHandler: ConvertErrorHandler,
+    private val jsonErrorHandler: ReportingConvertErrorHandler,
     private val methodInfo: MethodInfo
   ) : Converter<ResponseBody, T> {
     override fun convert(value: ResponseBody): T? {
@@ -107,7 +102,7 @@ class ErrorLoggingConverterFactory(
 
   private class RequestBodyErrorConverter<T>(
     private val delegate: Converter<T, RequestBody>,
-    private val jsonErrorHandler: ConvertErrorHandler,
+    private val jsonErrorHandler: ReportingConvertErrorHandler,
     private val methodInfo: MethodInfo
   ) : Converter<T, RequestBody> {
     override fun convert(value: T): RequestBody? {

--- a/core/src/main/java/com/jraska/github/client/http/ErrorLoggingConverterFactory.kt
+++ b/core/src/main/java/com/jraska/github/client/http/ErrorLoggingConverterFactory.kt
@@ -86,14 +86,14 @@ class ErrorLoggingConverterFactory(
 
   private class ResponseBodyErrorConverter<T>(
     private val delegate: Converter<ResponseBody, T>,
-    private val jsonErrorHandler: ReportingConvertErrorHandler,
+    private val errorHandler: ReportingConvertErrorHandler,
     private val methodInfo: MethodInfo
   ) : Converter<ResponseBody, T> {
     override fun convert(value: ResponseBody): T? {
       try {
         return delegate.convert(value)
       } catch (exception: Exception) {
-        jsonErrorHandler.onConvertResponseError(exception, methodInfo)
+        errorHandler.onConvertResponseError(exception, methodInfo)
 
         throw exception
       }
@@ -102,14 +102,14 @@ class ErrorLoggingConverterFactory(
 
   private class RequestBodyErrorConverter<T>(
     private val delegate: Converter<T, RequestBody>,
-    private val jsonErrorHandler: ReportingConvertErrorHandler,
+    private val errorHandler: ReportingConvertErrorHandler,
     private val methodInfo: MethodInfo
   ) : Converter<T, RequestBody> {
     override fun convert(value: T): RequestBody? {
       try {
         return delegate.convert(value)
       } catch (exception: Exception) {
-        jsonErrorHandler.onConvertRequestBodyError(value as Any, exception, methodInfo)
+        errorHandler.onConvertRequestBodyError(value as Any, exception, methodInfo)
 
         throw exception
       }

--- a/core/src/main/java/com/jraska/github/client/http/HttpModule.kt
+++ b/core/src/main/java/com/jraska/github/client/http/HttpModule.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
 object HttpModule {
   @Provides
   @Singleton
-  fun provideRetrofit(okHttpClient: OkHttpClient, jsonErrorHandler: ReportingConvertErrorHandler): Retrofit {
+  fun provideRetrofit(okHttpClient: OkHttpClient, errorHandler: ReportingConvertErrorHandler): Retrofit {
     return Retrofit.Builder()
       .baseUrl("https://api.github.com")
       .validateEagerly(BuildConfig.DEBUG)
@@ -30,7 +30,7 @@ object HttpModule {
       .addConverterFactory(
         ErrorLoggingConverterFactory(
           GsonConverterFactory.create(),
-          jsonErrorHandler
+          errorHandler
         )
       )
       .build()

--- a/core/src/main/java/com/jraska/github/client/http/HttpModule.kt
+++ b/core/src/main/java/com/jraska/github/client/http/HttpModule.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
 object HttpModule {
   @Provides
   @Singleton
-  fun provideRetrofit(okHttpClient: OkHttpClient, jsonErrorHandler: ConvertErrorHandler): Retrofit {
+  fun provideRetrofit(okHttpClient: OkHttpClient, jsonErrorHandler: ReportingConvertErrorHandler): Retrofit {
     return Retrofit.Builder()
       .baseUrl("https://api.github.com")
       .validateEagerly(BuildConfig.DEBUG)
@@ -76,7 +76,4 @@ object HttpModule {
   internal fun appVersion(context: Context): AppVersion {
     return AndroidAppVersion(context)
   }
-
-  @Provides
-  fun convertErrorHandler(handler: ReportingConvertErrorHandler): ConvertErrorHandler = handler
 }

--- a/core/src/main/java/com/jraska/github/client/http/ReportingConvertErrorHandler.kt
+++ b/core/src/main/java/com/jraska/github/client/http/ReportingConvertErrorHandler.kt
@@ -7,9 +7,9 @@ import javax.inject.Inject
 
 class ReportingConvertErrorHandler @Inject constructor(
   private val eventAnalytics: EventAnalytics
-) : ConvertErrorHandler {
+) {
 
-  override fun onConvertRequestBodyError(value: Any, exception: Exception, methodInfo: MethodInfo) {
+  fun onConvertRequestBodyError(value: Any, exception: Exception, methodInfo: MethodInfo) {
     val requestBodyError = AnalyticsEvent.builder(REQUEST_CONVERT_ERROR)
       .addExceptionProperties(exception, methodInfo)
       .addProperty("value_type", value::class.qualifiedName.max100End())
@@ -18,7 +18,7 @@ class ReportingConvertErrorHandler @Inject constructor(
     eventAnalytics.report(requestBodyError)
   }
 
-  override fun onConvertResponseError(exception: Exception, methodInfo: MethodInfo) {
+  fun onConvertResponseError(exception: Exception, methodInfo: MethodInfo) {
     val responseBodyError = AnalyticsEvent.builder(RESPONSE_CONVERT_ERROR)
       .addExceptionProperties(exception, methodInfo)
       .build()
@@ -30,7 +30,7 @@ class ReportingConvertErrorHandler @Inject constructor(
     exception: Exception,
     methodInfo: MethodInfo,
   ): AnalyticsEvent.Builder {
-    val dtoType = if(methodInfo.dtoType is Class<*>) {
+    val dtoType = if (methodInfo.dtoType is Class<*>) {
       methodInfo.dtoType.name
     } else {
       methodInfo.dtoType.toString()
@@ -62,7 +62,7 @@ class ReportingConvertErrorHandler @Inject constructor(
   private fun String.omitQueryParams(): String {
     val questionIndex: Int = indexOf('?')
 
-    if(questionIndex > 0) {
+    if (questionIndex > 0) {
       return substring(0, questionIndex)
     } else {
       return this


### PR DESCRIPTION
- [Complexity Strikes Back by Hadi Hariri](https://www.droidcon.com/2022/11/18/keynote-the-silver-bullet-syndrome-directors-cut-complexity-strikes-back/) time `37:45`
- `ConvertErrorHandler` had always a single implementation and wasn't used across modules
- The test is an integration one, therefore no change was required
- Indirection, extra interface and Dagger binding removed.
- I got tired of modifying multiple places due to iterations on the interface.
- We can always refactor interface out if necessary