### PR TITLE
Remove Firebase In App Messaging

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,6 @@ dependencies {
   implementation 'com.google.firebase:firebase-config'
   implementation 'com.google.firebase:firebase-crashlytics'
   implementation 'com.google.firebase:firebase-messaging'
-  implementation 'com.google.firebase:firebase-inappmessaging-display'
   implementation 'com.google.firebase:firebase-database'
 
   implementation fresco


### PR DESCRIPTION
It was huge part of the app - unused.

```
Total app size diff: 
Download: -432.42 kB, Install: -438.67 kB
----------------------------------------------Removed-----------------------------------------------
- com.github.bumptech.glide:glide:4.11.0 Download: 75.21 kB, Install: 75.5 kB
- io.grpc:grpc-core:1.52.1 Download: 65.68 kB, Install: 65.94 kB
- io.reactivex.rxjava2:rxjava:2.1.14 Download: 54.34 kB, Install: 54.56 kB
- com.google.protobuf:protobuf-javalite:3.21.7 Download: 51.63 kB, Install: 51.83 kB
- com.google.firebase:firebase-inappmessaging:20.3.3 Download: 39.09 kB, Install: 39.23 kB
- io.grpc:grpc-okhttp:1.52.1 Download: 32.5 kB, Install: 32.63 kB
- io.grpc:grpc-api:1.52.1 Download: 21.98 kB, Install: 22.07 kB
- com.google.firebase:firebase-inappmessaging-display:20.3.3 Download: 21.64 kB, Install: 21.69 kB
- com.google.guava:guava:31.1-android Download: 15.79 kB, Install: 15.85 kB
- androidx.exifinterface:exifinterface:1.0.0 Download: 10.04 kB, Install: 10.07 kB
- com.github.bumptech.glide:disklrucache:4.11.0 Download: 6.28 kB, Install: 6.3 kB
- com.github.bumptech.glide:gifdecoder:4.11.0 Download: 3.16 kB, Install: 3.17 kB
- io.grpc:grpc-context:1.52.1 Download: 2.24 kB, Install: 2.25 kB
- io.grpc:grpc-stub:1.52.1 Download: 1.5 kB, Install: 1.5 kB
- io.perfmark:perfmark-api:0.25.0 Download: 1.38 kB, Install: 1.38 kB
- io.reactivex.rxjava2:rxandroid:2.0.2 Download: 847 B, Install: 851 B
- io.grpc:grpc-protobuf-lite:1.52.1 Download: 473 B, Install: 474 B
- org.reactivestreams:reactive-streams:1.0.2 Download: 169 B, Install: 170 B
```